### PR TITLE
Remove unused rdkafka dependency

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -17,7 +17,6 @@ bb8 = { version = "0.8", optional = true }
 bb8-redis = { version = "0.13", optional = true }
 futures = { version = "0.3", default-features = false, features = ["async-await", "std"] }
 lapin = { version = "2", optional = true }
-rdkafka = { version = "0.29", features = ["cmake-build", "ssl", "tracing"] }
 redis = { version = "0.23", features = ["tokio-comp", "tokio-native-tls-comp", "streams"], optional = true }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"


### PR DESCRIPTION
I'm guessing there was a kafka backend planned or in progress, but it's not available at the moment, so this should either be made optional with a feature or removed entirely.