### PR TITLE
Run cargo fmt with latest version

### DIFF
--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -81,7 +81,9 @@ impl Delivery {
     ///
     /// This method does not consume the payload.
     pub fn payload_custom<T: 'static>(&self) -> Result<Option<T>, QueueError> {
-        let Some(payload) = self.payload.as_ref() else { return Ok(None); };
+        let Some(payload) = self.payload.as_ref() else {
+            return Ok(None);
+        };
 
         let decoder = self
             .decoders
@@ -107,7 +109,9 @@ impl Delivery {
     }
 
     pub fn payload_serde_json<T: DeserializeOwned>(&self) -> Result<Option<T>, QueueError> {
-        let Some(bytes) = self.payload.as_ref() else { return Ok(None); };
+        let Some(bytes) = self.payload.as_ref() else {
+            return Ok(None);
+        };
         serde_json::from_slice(bytes).map_err(Into::into)
     }
 }


### PR DESCRIPTION
One of the updates to `rustfmt` since the last change to this crate including additional rules for the `let ... else ...` syntax. This change simply runs `cargo fmt` to appease linting.