### PR TITLE
make `Acker` require `Send+Sync`, re-export redis connection manager

### DIFF
--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -2,7 +2,7 @@ use std::{any::TypeId, collections::HashMap, marker::PhantomData};
 
 use async_trait::async_trait;
 use bb8::ManageConnection;
-use bb8_redis::RedisMultiplexedConnectionManager;
+pub use bb8_redis::RedisMultiplexedConnectionManager;
 use redis::streams::{StreamReadOptions, StreamReadReply};
 
 use crate::{

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -117,7 +117,7 @@ impl Delivery {
 }
 
 #[async_trait]
-pub trait Acker {
+pub trait Acker: Send + Sync {
     async fn ack(&mut self) -> Result<(), QueueError>;
     async fn nack(&mut self) -> Result<(), QueueError>;
 }


### PR DESCRIPTION
While updating bridge to use omniqueue, the usages already in place
work, mostly as-is, with these two changes.

WRT the redis re-export, rust was not able to infer to generic type for
a Producer or Consumer and required that I specify the type for `R`.
Rather than adding a dep on bb8 in bridge, it would be nicer to just
have it re-exported.

WRT `Acker`, bridge expected to run a consumer loop then hand each
`Delivery` off to an async "handler" function. This failed to compile
as-is citing the lack of `Send+Sync`. Making `Acker` a supertrait of
`Send+Sync` was trivial since all the existing implementations were
naturally `Send+Sync`, so this is probably not controversial.