### PR TITLE
add `Consumer::receive_all`

### DIFF
--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -129,6 +129,8 @@ pub enum QueueError {
 
     #[error("{0}")]
     Generic(Box<dyn std::error::Error + Send + Sync>),
+    #[error("{0}")]
+    Unsupported(&'static str),
 }
 
 impl QueueError {

--- a/omniqueue/src/queue/consumer.rs
+++ b/omniqueue/src/queue/consumer.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::time::Duration;
 
 use crate::{decoding::DecoderRegistry, QueueError, QueuePayload};
 
@@ -9,6 +10,12 @@ pub trait QueueConsumer: Send + Sync {
     type Payload: QueuePayload;
 
     async fn receive(&mut self) -> Result<Delivery, QueueError>;
+
+    async fn receive_all(
+        &mut self,
+        max_messages: usize,
+        deadline: Duration,
+    ) -> Result<Vec<Delivery>, QueueError>;
 
     fn into_dyn(self, custom_decoders: DecoderRegistry<Vec<u8>>) -> DynConsumer
     where
@@ -48,6 +55,28 @@ impl<T: QueuePayload, C: 'static + QueueConsumer<Payload = T>> QueueConsumer
         })
     }
 
+    async fn receive_all(
+        &mut self,
+        max_messages: usize,
+        deadline: Duration,
+    ) -> Result<Vec<Delivery>, QueueError> {
+        let xs = self.inner.receive_all(max_messages, deadline).await?;
+        let mut out = Vec::with_capacity(xs.len());
+        for mut t_payload in xs {
+            let bytes_payload: Option<Vec<u8>> = match t_payload.payload_custom() {
+                Ok(b) => b,
+                Err(QueueError::NoDecoderForThisType) => t_payload.take_payload(),
+                Err(e) => return Err(e),
+            };
+            out.push(Delivery {
+                payload: bytes_payload,
+                decoders: self.custom_decoders.clone(),
+                acker: t_payload.acker,
+            });
+        }
+        Ok(out)
+    }
+
     fn into_dyn(mut self, custom_decoders: DecoderRegistry<Vec<u8>>) -> DynConsumer
     where
         Self: Sized,
@@ -65,6 +94,14 @@ impl QueueConsumer for DynConsumer {
 
     async fn receive(&mut self) -> Result<Delivery, QueueError> {
         self.0.receive().await
+    }
+
+    async fn receive_all(
+        &mut self,
+        max_messages: usize,
+        deadline: Duration,
+    ) -> Result<Vec<Delivery>, QueueError> {
+        self.0.receive_all(max_messages, deadline).await
     }
 
     fn into_dyn(self, _custom_decoders: DecoderRegistry<Vec<u8>>) -> DynConsumer

--- a/omniqueue/tests/gcp_pubsub.rs
+++ b/omniqueue/tests/gcp_pubsub.rs
@@ -54,6 +54,7 @@
 use google_cloud_googleapis::pubsub::v1::DeadLetterPolicy;
 use google_cloud_pubsub::client::{Client, ClientConfig};
 use google_cloud_pubsub::subscription::SubscriptionConfig;
+use std::time::{Duration, Instant};
 
 use omniqueue::backends::gcp_pubsub::{GcpPubSubBackend, GcpPubSubConfig};
 use omniqueue::queue::{
@@ -195,4 +196,113 @@ async fn test_custom_send_recv() {
     // Because it doesn't use JSON, this should fail:
     d.payload_serde_json::<ExType>().unwrap_err();
     d.ack().await.unwrap();
+}
+
+/// Consumer will return immediately if there are fewer than max messages to start with.
+#[tokio::test]
+async fn test_send_recv_all_partial() {
+    let payload = ExType { a: 2 };
+    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload).await.unwrap();
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 1);
+    let d = xs.remove(0);
+    assert_eq!(d.payload_serde_json::<ExType>().unwrap().unwrap(), payload);
+    d.ack().await.unwrap();
+    assert!(now.elapsed() <= deadline);
+}
+
+/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+#[tokio::test]
+async fn test_send_recv_all_full() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    // N.b. it's still possible this could turn up false if the test runs too slow.
+    assert!(now.elapsed() < deadline);
+}
+
+/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+#[tokio::test]
+async fn test_send_recv_all_full_then_partial() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let payload3 = ExType { a: 3 };
+    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    p.send_serde_json(&payload3).await.unwrap();
+
+    let deadline = Duration::from_secs(1);
+    let now1 = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    assert!(now1.elapsed() < deadline);
+
+    // 2nd call
+    let now2 = Instant::now();
+    let mut ys = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(ys.len(), 1);
+    let d3 = ys.remove(0);
+    assert_eq!(
+        d3.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload3
+    );
+    d3.ack().await.unwrap();
+    assert!(now2.elapsed() <= deadline);
+}
+
+/// Consumer will NOT wait indefinitely for at least one item.
+#[tokio::test]
+async fn test_send_recv_all_late_arriving_items() {
+    let (_p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    let deadline = Duration::from_secs(1);
+    let now = Instant::now();
+    let xs = c.receive_all(2, deadline).await.unwrap();
+    let elapsed = now.elapsed();
+
+    assert_eq!(xs.len(), 0);
+    // Elapsed should be around the deadline, ballpark
+    assert!(elapsed >= deadline);
+    assert!(elapsed <= deadline + Duration::from_millis(200));
 }

--- a/omniqueue/tests/rabbitmq.rs
+++ b/omniqueue/tests/rabbitmq.rs
@@ -8,6 +8,7 @@ use omniqueue::{
     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend, QueueBuilder, Static},
 };
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
 
 const MQ_URI: &str = "amqp://guest:guest@localhost:5672/%2f";
 
@@ -16,7 +17,10 @@ const MQ_URI: &str = "amqp://guest:guest@localhost:5672/%2f";
 ///
 /// Additionally this will make a temporary queue on that instance for the duration of the test such
 /// as to ensure there is no stealing.w
-async fn make_test_queue(reinsert_on_nack: bool) -> QueueBuilder<RabbitMqBackend, Static> {
+async fn make_test_queue(
+    prefetch_count: Option<u16>,
+    reinsert_on_nack: bool,
+) -> QueueBuilder<RabbitMqBackend, Static> {
     let options = ConnectionProperties::default()
         .with_connection_name(
             std::iter::repeat_with(fastrand::alphanumeric)
@@ -51,11 +55,12 @@ async fn make_test_queue(reinsert_on_nack: bool) -> QueueBuilder<RabbitMqBackend
         publish_exchange: "".to_owned(),
         publish_routing_key: queue_name.clone(),
         publish_options: BasicPublishOptions::default(),
-        publish_properites: BasicProperties::default(),
+        publish_properties: BasicProperties::default(),
         consume_queue: queue_name,
         consumer_tag: "test".to_owned(),
         consume_options: BasicConsumeOptions::default(),
         consume_arguments: FieldTable::default(),
+        consume_prefetch_count: prefetch_count,
         requeue_on_nack: reinsert_on_nack,
     };
 
@@ -65,7 +70,11 @@ async fn make_test_queue(reinsert_on_nack: bool) -> QueueBuilder<RabbitMqBackend
 #[tokio::test]
 async fn test_bytes_send_recv() {
     let payload = b"hello";
-    let (p, mut c) = make_test_queue(false).await.build_pair().await.unwrap();
+    let (p, mut c) = make_test_queue(None, false)
+        .await
+        .build_pair()
+        .await
+        .unwrap();
 
     p.send_bytes(payload).await.unwrap();
 
@@ -89,7 +98,11 @@ pub struct ExType {
 #[tokio::test]
 async fn test_serde_send_recv() {
     let payload = ExType { a: 2 };
-    let (p, mut c) = make_test_queue(false).await.build_pair().await.unwrap();
+    let (p, mut c) = make_test_queue(None, false)
+        .await
+        .build_pair()
+        .await
+        .unwrap();
 
     p.send_serde_json(&payload).await.unwrap();
 
@@ -109,7 +122,7 @@ async fn test_custom_send_recv() {
         })
     };
 
-    let (p, mut c) = make_test_queue(false)
+    let (p, mut c) = make_test_queue(None, false)
         .await
         .with_encoder(encoder)
         .with_decoder(decoder)
@@ -125,4 +138,137 @@ async fn test_custom_send_recv() {
     // Because it doesn't use JSON, this should fail:
     d.payload_serde_json::<ExType>().unwrap_err();
     d.ack().await.unwrap();
+}
+
+/// Consumer will return immediately if there are fewer than max messages to start with.
+#[tokio::test]
+async fn test_send_recv_all_partial() {
+    let payload = ExType { a: 2 };
+    let (p, mut c) = make_test_queue(None, false)
+        .await
+        .build_pair()
+        .await
+        .unwrap();
+
+    p.send_serde_json(&payload).await.unwrap();
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 1);
+    let d = xs.remove(0);
+    assert_eq!(d.payload_serde_json::<ExType>().unwrap().unwrap(), payload);
+    d.ack().await.unwrap();
+    assert!(now.elapsed() <= deadline);
+}
+
+/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+#[tokio::test]
+async fn test_send_recv_all_full() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let (p, mut c) = make_test_queue(None, false)
+        .await
+        .build_pair()
+        .await
+        .unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+
+    // XXX: rabbit's receive_all impl relies on stream items to be in a ready state in order for
+    // them to be batched together. Sleeping to help them settle before we poll.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    // N.b. it's still possible this could turn up false if the test runs too slow.
+    assert!(now.elapsed() < deadline);
+}
+
+/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+#[tokio::test]
+async fn test_send_recv_all_full_then_partial() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let payload3 = ExType { a: 3 };
+    let (p, mut c) = make_test_queue(None, false)
+        .await
+        .build_pair()
+        .await
+        .unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    p.send_serde_json(&payload3).await.unwrap();
+
+    // XXX: rabbit's receive_all impl relies on stream items to be in a ready state in order for
+    // them to be batched together. Sleeping to help them settle before we poll.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let deadline = Duration::from_secs(1);
+    let now1 = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    assert!(now1.elapsed() < deadline);
+
+    // 2nd call
+    let now2 = Instant::now();
+    let mut ys = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(ys.len(), 1);
+    let d3 = ys.remove(0);
+    assert_eq!(
+        d3.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload3
+    );
+    d3.ack().await.unwrap();
+    assert!(now2.elapsed() <= deadline);
+}
+
+/// Consumer will NOT wait indefinitely for at least one item.
+#[tokio::test]
+async fn test_send_recv_all_late_arriving_items() {
+    let (_p, mut c) = make_test_queue(None, false)
+        .await
+        .build_pair()
+        .await
+        .unwrap();
+
+    let deadline = Duration::from_secs(1);
+    let now = Instant::now();
+    let xs = c.receive_all(2, deadline).await.unwrap();
+    let elapsed = now.elapsed();
+
+    assert_eq!(xs.len(), 0);
+    // Elapsed should be around the deadline, ballpark
+    assert!(elapsed >= deadline);
+    assert!(elapsed <= deadline + Duration::from_millis(200));
 }

--- a/omniqueue/tests/redis.rs
+++ b/omniqueue/tests/redis.rs
@@ -4,6 +4,7 @@ use omniqueue::{
 };
 use redis::{AsyncCommands, Client, Commands};
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
 
 const ROOT_URL: &str = "redis://localhost";
 
@@ -122,4 +123,123 @@ async fn test_custom_send_recv() {
     // Because it doesn't use JSON, this should fail:
     d.payload_serde_json::<ExType>().unwrap_err();
     d.ack().await.unwrap();
+}
+
+/// Consumer will return immediately if there are fewer than max messages to start with.
+#[tokio::test]
+async fn test_send_recv_all_partial() {
+    let (builder, _drop) = make_test_queue().await;
+
+    let payload = ExType { a: 2 };
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload).await.unwrap();
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 1);
+    let d = xs.remove(0);
+    assert_eq!(d.payload_serde_json::<ExType>().unwrap().unwrap(), payload);
+    d.ack().await.unwrap();
+    assert!(now.elapsed() <= deadline);
+}
+
+/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+#[tokio::test]
+async fn test_send_recv_all_full() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+
+    let (builder, _drop) = make_test_queue().await;
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    // N.b. it's still possible this could turn up false if the test runs too slow.
+    assert!(now.elapsed() < deadline);
+}
+
+/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+#[tokio::test]
+async fn test_send_recv_all_full_then_partial() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let payload3 = ExType { a: 3 };
+
+    let (builder, _drop) = make_test_queue().await;
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    p.send_serde_json(&payload3).await.unwrap();
+
+    let deadline = Duration::from_secs(1);
+    let now1 = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    assert!(now1.elapsed() < deadline);
+
+    // 2nd call
+    let now2 = Instant::now();
+    let mut ys = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(ys.len(), 1);
+    let d3 = ys.remove(0);
+    assert_eq!(
+        d3.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload3
+    );
+    d3.ack().await.unwrap();
+    assert!(now2.elapsed() < deadline);
+}
+
+/// Consumer will NOT wait indefinitely for at least one item.
+#[tokio::test]
+async fn test_send_recv_all_late_arriving_items() {
+    let (builder, _drop) = make_test_queue().await;
+
+    let (_p, mut c) = builder.build_pair().await.unwrap();
+
+    let deadline = Duration::from_secs(1);
+    let now = Instant::now();
+    let xs = c.receive_all(2, deadline).await.unwrap();
+    let elapsed = now.elapsed();
+
+    assert_eq!(xs.len(), 0);
+    // Elapsed should be around the deadline, ballpark
+    assert!(elapsed >= deadline);
+    assert!(elapsed <= deadline + Duration::from_millis(200));
 }

--- a/omniqueue/tests/sqs.rs
+++ b/omniqueue/tests/sqs.rs
@@ -4,6 +4,7 @@ use omniqueue::{
     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend, QueueBuilder, Static},
 };
 use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
 
 const ROOT_URL: &str = "http://localhost:9324";
 const DEFAULT_CFG: [(&str, &str); 3] = [
@@ -112,4 +113,113 @@ async fn test_custom_send_recv() {
     // Because it doesn't use JSON, this should fail:
     d.payload_serde_json::<ExType>().unwrap_err();
     d.ack().await.unwrap();
+}
+
+/// Consumer will return immediately if there are fewer than max messages to start with.
+#[tokio::test]
+async fn test_send_recv_all_partial() {
+    let payload = ExType { a: 2 };
+    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload).await.unwrap();
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 1);
+    let d = xs.remove(0);
+    assert_eq!(d.payload_serde_json::<ExType>().unwrap().unwrap(), payload);
+    d.ack().await.unwrap();
+    assert!(now.elapsed() <= deadline);
+}
+
+/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+#[tokio::test]
+async fn test_send_recv_all_full() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    let deadline = Duration::from_secs(1);
+
+    let now = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    // N.b. it's still possible this could turn up false if the test runs too slow.
+    assert!(now.elapsed() < deadline);
+}
+
+/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+#[tokio::test]
+async fn test_send_recv_all_full_then_partial() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let payload3 = ExType { a: 3 };
+    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    p.send_serde_json(&payload3).await.unwrap();
+
+    let deadline = Duration::from_secs(1);
+    let now1 = Instant::now();
+    let mut xs = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(xs.len(), 2);
+    let d1 = xs.remove(0);
+    assert_eq!(
+        d1.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload1
+    );
+    d1.ack().await.unwrap();
+
+    let d2 = xs.remove(0);
+    assert_eq!(
+        d2.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload2
+    );
+    d2.ack().await.unwrap();
+    assert!(now1.elapsed() < deadline);
+
+    // 2nd call
+    let now2 = Instant::now();
+    let mut ys = c.receive_all(2, deadline).await.unwrap();
+    assert_eq!(ys.len(), 1);
+    let d3 = ys.remove(0);
+    assert_eq!(
+        d3.payload_serde_json::<ExType>().unwrap().unwrap(),
+        payload3
+    );
+    d3.ack().await.unwrap();
+    assert!(now2.elapsed() < deadline);
+}
+
+/// Consumer will NOT wait indefinitely for at least one item.
+#[tokio::test]
+async fn test_send_recv_all_late_arriving_items() {
+    let (_p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+
+    let deadline = Duration::from_secs(1);
+    let now = Instant::now();
+    let xs = c.receive_all(2, deadline).await.unwrap();
+    let elapsed = now.elapsed();
+
+    assert_eq!(xs.len(), 0);
+    // Elapsed should be around the deadline, ballpark
+    assert!(elapsed >= deadline);
+    assert!(elapsed <= deadline + Duration::from_millis(200));
 }


### PR DESCRIPTION
~~Support for batched reads is not uniform among the various backends we have.
In some cases, partial batches will wait longer or shorter than the specified deadline.~~

~~The odd one out right now is RabbitMQ which supports configuring a channel with a pre-fetch limit, but you still have to just consume messages one-by-one (the batching is all under the hood). Additionally, there doesn't seem to be a way to specify a timeout or deadline (apparently this is left up to individual clients to decide what makes the most sense).~~

~~As such, RabbitMQ is under-served compared to the rest. The implementation for batch reads is entirely done in the client code (i.e. reading messages one-by-one, buffering them, then returning).~~

~~One possible solution is to add a max prefetch config option and use this when initializing a consumer channel, but this would also mean the `max_messages` argument would be meaningless for RabbitMQ, and using `receive_all` at all would probably be irrelevant. Callers should probably just use `receive` instead.~~

~~For now, I've left some comments in the rabbit impl and will leave this as future work.~~

---

Support for batched reads is not uniform among the various backends we have.
    
The in-memory and rabbitmq impls differ from the rest as these consumers are channel/stream based, with no explicit option for consuming messages in batches.
    
Using `tokio::time::timeout` for the first item, then looping to opportunistically try to fill up the batch with any remaining _already ready_ messages, we can emulate a similar behavior as the other backends.
    
In all cases, receive_all should:
- not block longer (+/-) than the specified deadline, even if no items
  are available.
- not linger waiting for _more items_ once it as received _any_.

Additionally, a new bit of config has been exposed for rabbitmq so callers can specify a prefetch count. This didn't seem to have any impact on the tests, but seems good to have.