### PR TITLE
feat(redis): add "pending" task to re-queue unhandled messages

### DIFF
--- a/omniqueue/tests/redis_cluster.rs
+++ b/omniqueue/tests/redis_cluster.rs
@@ -50,6 +50,7 @@ async fn make_test_queue() -> (
         consumer_group: "test_cg".to_owned(),
         consumer_name: "test_cn".to_owned(),
         payload_key: "payload".to_owned(),
+        ack_deadline_ms: 5_000,
     };
 
     (
@@ -269,4 +270,51 @@ async fn test_scheduled() {
     assert!(now.elapsed() >= delay);
     assert!(now.elapsed() < delay * 2);
     assert_eq!(Some(payload1), delivery.payload_serde_json().unwrap());
+}
+
+#[tokio::test]
+async fn test_pending() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let (builder, _drop) = make_test_queue().await;
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    let delivery1 = c.receive().await.unwrap();
+    let delivery2 = c.receive().await.unwrap();
+
+    // All items claimed, but not yet ack'd. There shouldn't be anything available yet.
+    assert!(c
+        .receive_all(1, Duration::from_millis(1))
+        .await
+        .unwrap()
+        .is_empty());
+
+    assert_eq!(
+        Some(&payload1),
+        delivery1.payload_serde_json().unwrap().as_ref()
+    );
+    assert_eq!(
+        Some(&payload2),
+        delivery2.payload_serde_json().unwrap().as_ref()
+    );
+
+    // ack 2, but neglect 1
+    let _ = delivery2.ack().await;
+
+    // After the deadline, the first payload should appear again.
+    let delivery3 = c.receive().await.unwrap();
+    assert_eq!(
+        Some(&payload1),
+        delivery3.payload_serde_json().unwrap().as_ref()
+    );
+
+    // queue should be empty once again
+    assert!(c
+        .receive_all(1, Duration::from_millis(1))
+        .await
+        .unwrap()
+        .is_empty());
 }


### PR DESCRIPTION
In svix-server's redis queue implementation, there's a spawned task to look for messages that have been "claimed" (i.e. pulled off the queue) but not ack'd or nack'd within some deadline period.

This was missing from the omniqueue version, added in this diff.

This refactors the prior background task spawned for delayed messages so it and the new one for the pending sweeper are bundled together in a `JoinSet`. 
Since dropping a `JoinSet` means the spawned tasks under it will abort, the handle is now held by any consumers/producers that share the same config.