### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust: [stable, beta]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,41 +14,30 @@ jobs:
       matrix:
         rust: [stable, beta]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@master
 
-    - uses: actions-rs/toolchain@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        override: true
-        profile: minimal
         components: clippy, rustfmt
 
     - uses: Swatinem/rust-cache@v1
 
     - name: Clippy
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --all --all-targets --all-features -- -D warnings
+      run: cargo clippy --all --all-targets --all-features -- -D warnings
 
     - name: rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
     - name: Start test dependencies
       run: docker-compose -f "./testing-docker-compose.yml" up -d
 
     - name: Run tests
-      uses: actions-rs/cargo@v1
       env:
         AWS_DEFAULT_REGION: localhost
         AWS_ACCESS_KEY_ID: x
         AWS_SECRET_ACCESS_KEY: x
-      with:
-        command: test
-        args: --all --all-features
+      run: cargo test --all --all-features
 
     - name: Stop test dependencies
       run: docker-compose -f "./testing-docker-compose.yml" down

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'omniqueue/**'
-      - '.github/workflows/lint.yml'
   pull_request:
-    paths:
-      - 'omniqueue/**'
-      - '.github/workflows/lint.yml'
 
 jobs:
   test-versions:
@@ -30,20 +24,18 @@ jobs:
         components: clippy, rustfmt
 
     - uses: Swatinem/rust-cache@v1
-      with:
-        working-directory: omniqueue
 
     - name: Clippy
       uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --manifest-path omniqueue/Cargo.toml --all --all-targets --all-features -- -D warnings
+        args: --all --all-targets --all-features -- -D warnings
 
     - name: rustfmt
       uses: actions-rs/cargo@v1
       with:
         command: fmt
-        args: --manifest-path omniqueue/Cargo.toml --all -- --check
+        args: --all -- --check
 
     - name: Start test dependencies
       run: docker-compose -f "./testing-docker-compose.yml" up -d
@@ -56,7 +48,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: x
       with:
         command: test
-        args: --manifest-path omniqueue/Cargo.toml --all --all-features
+        args: --all --all-features
 
     - name: Stop test dependencies
       run: docker-compose -f "./testing-docker-compose.yml" down

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,10 +24,10 @@ jobs:
     - uses: Swatinem/rust-cache@v1
 
     - name: Clippy
-      run: cargo clippy --all --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets --all-features -- -D warnings
 
     - name: rustfmt
-      run: cargo fmt --all -- --check
+      run: cargo fmt -- --check
 
     - name: Start test dependencies
       run: docker-compose -f "./testing-docker-compose.yml" up -d
@@ -37,7 +37,7 @@ jobs:
         AWS_DEFAULT_REGION: localhost
         AWS_ACCESS_KEY_ID: x
         AWS_SECRET_ACCESS_KEY: x
-      run: cargo test --all --all-features
+      run: cargo test --all-features
 
     - name: Stop test dependencies
       run: docker-compose -f "./testing-docker-compose.yml" down

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+env:
+  CARGO_TERM_COLOR: always
+
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:
@@ -19,7 +19,7 @@ jobs:
           profile: minimal
           components: clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
 
       - name: Publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  CARGO_TERM_COLOR: always
+
 on:
   push:
     tags:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,15 +3,13 @@ name: Rust Lib Security
 on:
   push:
     branches:
-    - main
+      - main
     paths:
-      - 'omniqueue/Cargo.toml'
-      - 'omniqueue/Cargo.lock'
+      - '**/Cargo.toml'
       - '.github/workflows/rust-security.yml'
   pull_request:
     paths:
-      - 'omniqueue/Cargo.toml'
-      - 'omniqueue/Cargo.lock'
+      - '**/Cargo.toml'
       - '.github/workflows/rust-security.yml'
 
 jobs:
@@ -20,5 +18,3 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
-        with:
-            arguments: --manifest-path=omniqueue/Cargo.toml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
 name: Rust Lib Security
 
+env:
+  CARGO_TERM_COLOR: always
+
 on:
   push:
     branches:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,5 +16,5 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
Lots of small improvements. Maybe most importantly, this gets rid of deprecation warnings about [Node 16 actions](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/), which the deprecated / archived `actions-rs` actions were triggering:

![Screenshot 2024-02-06 at 09-50-27 server Some redis queue refactorings · svix_svix-webhooks@8012e6c](https://github.com/svix/omniqueue-rs/assets/158304798/48805f74-65fc-49bd-872d-bdf037b6f1e8)
