### PR TITLE
Add missing cfg attributes

### DIFF
--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -46,7 +46,9 @@ use crate::{
     QueueError,
 };
 
+#[cfg(feature = "redis_cluster")]
 mod cluster;
+#[cfg(feature = "redis_cluster")]
 use cluster::RedisClusterConnectionManager;
 
 pub trait RedisConnection
@@ -64,6 +66,7 @@ impl RedisConnection for RedisMultiplexedConnectionManager {
     }
 }
 
+#[cfg(feature = "redis_cluster")]
 impl RedisConnection for RedisClusterConnectionManager {
     fn from_dsn(dsn: &str) -> Result<Self, QueueError> {
         Self::new(dsn).map_err(QueueError::generic)
@@ -83,6 +86,7 @@ pub struct RedisConfig {
 }
 
 pub struct RedisQueueBackend<R = RedisMultiplexedConnectionManager>(PhantomData<R>);
+#[cfg(feature = "redis_cluster")]
 pub type RedisClusterQueueBackend = RedisQueueBackend<RedisClusterConnectionManager>;
 
 type RawPayload = Vec<u8>;

--- a/omniqueue/tests/gcp_pubsub.rs
+++ b/omniqueue/tests/gcp_pubsub.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "gcp_pubsub")]
+
 //! Support for Google Cloud Pub/Sub.
 //!
 //! In this system subscriptions are like queue bindings to topics.

--- a/omniqueue/tests/rabbitmq.rs
+++ b/omniqueue/tests/rabbitmq.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rabbitmq")]
+
 use lapin::options::ExchangeDeclareOptions;
 use lapin::types::AMQPValue;
 use lapin::{

--- a/omniqueue/tests/redis.rs
+++ b/omniqueue/tests/redis.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "redis")]
+
 use omniqueue::{
     backends::redis::{RedisConfig, RedisQueueBackend},
     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend, QueueBuilder, Static},

--- a/omniqueue/tests/redis_cluster.rs
+++ b/omniqueue/tests/redis_cluster.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "redis_cluster")]
+
 use omniqueue::{
     backends::redis::{RedisClusterQueueBackend, RedisConfig},
     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend, QueueBuilder, Static},

--- a/omniqueue/tests/sqs.rs
+++ b/omniqueue/tests/sqs.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sqs")]
+
 use aws_sdk_sqs::Client;
 use omniqueue::{
     backends::sqs::{SqsConfig, SqsQueueBackend},


### PR DESCRIPTION
Fixes running tests with only a subset of backends enabled, as well as building the library with redis enabled but redis_cluster disabled.