### PR TITLE
Replace async_trait usage with RPITIT / AFIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 # Omniqueue
 
 Omniqueue is an abstraction layer over queue backends for Rust. It includes support for RabbitMQ,
-Redis streams, and SQS out of the box. The trait may also be implemented for other backends to meet
-your own needs.
+Redis streams, and SQS.
 
 Omniqueue provides a high level interface which allows sending and receiving raw byte arrays, any
 `serde` `Deserialize` and `Serialize` implementors via JSON encoded byte arrays, or any arbitrary

--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -6,7 +6,7 @@ description = "An abstraction layer over various queue backends"
 authors = ["Svix Inc. <oss@svix.com>"]
 repository = "https://github.com/svix/omniqueue-rs/"
 readme = "../README.md"
-
+rust-version = "1.75"
 edition = "2021"
 
 [dependencies]

--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -271,7 +271,7 @@ impl QueueConsumer for GcpPubSubConsumer {
     }
 }
 
-pub struct GcpPubSubAcker {
+struct GcpPubSubAcker {
     recv_msg: ReceivedMessage,
     subscription_id: Arc<String>,
 }

--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -99,7 +99,6 @@ impl GcpPubSubProducer {
     }
 }
 
-#[async_trait]
 impl QueueBackend for GcpPubSubBackend {
     type Config = GcpPubSubConfig;
 
@@ -152,7 +151,6 @@ impl std::fmt::Debug for GcpPubSubProducer {
     }
 }
 
-#[async_trait]
 impl QueueProducer for GcpPubSubProducer {
     type Payload = Payload;
 
@@ -237,7 +235,6 @@ impl GcpPubSubConsumer {
     }
 }
 
-#[async_trait]
 impl QueueConsumer for GcpPubSubConsumer {
     type Payload = Payload;
 

--- a/omniqueue/src/backends/memory_queue.rs
+++ b/omniqueue/src/backends/memory_queue.rs
@@ -163,7 +163,7 @@ impl QueueConsumer for MemoryQueueConsumer {
     }
 }
 
-pub struct MemoryQueueAcker {
+struct MemoryQueueAcker {
     tx: mpsc::UnboundedSender<Vec<u8>>,
     payload_copy: Option<Vec<u8>>,
     already_acked_or_nacked: bool,

--- a/omniqueue/src/backends/memory_queue.rs
+++ b/omniqueue/src/backends/memory_queue.rs
@@ -15,7 +15,6 @@ use crate::{
 
 pub struct MemoryQueueBackend;
 
-#[async_trait]
 impl QueueBackend for MemoryQueueBackend {
     type PayloadIn = Vec<u8>;
 
@@ -65,7 +64,6 @@ pub struct MemoryQueueProducer {
     tx: mpsc::UnboundedSender<Vec<u8>>,
 }
 
-#[async_trait]
 impl QueueProducer for MemoryQueueProducer {
     type Payload = Vec<u8>;
 
@@ -83,7 +81,6 @@ impl QueueProducer for MemoryQueueProducer {
     }
 }
 
-#[async_trait]
 impl ScheduledProducer for MemoryQueueProducer {
     async fn send_raw_scheduled(
         &self,
@@ -123,7 +120,6 @@ impl MemoryQueueConsumer {
     }
 }
 
-#[async_trait]
 impl QueueConsumer for MemoryQueueConsumer {
     type Payload = Vec<u8>;
 

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -88,7 +88,6 @@ async fn producer(
     })
 }
 
-#[async_trait]
 impl QueueBackend for RabbitMqBackend {
     type PayloadIn = Vec<u8>;
 
@@ -145,7 +144,6 @@ pub struct RabbitMqProducer {
     properties: BasicProperties,
 }
 
-#[async_trait]
 impl QueueProducer for RabbitMqProducer {
     type Payload = Vec<u8>;
 
@@ -169,7 +167,6 @@ impl QueueProducer for RabbitMqProducer {
     }
 }
 
-#[async_trait]
 impl ScheduledProducer for RabbitMqProducer {
     async fn send_raw_scheduled(
         &self,
@@ -218,7 +215,6 @@ impl RabbitMqConsumer {
     }
 }
 
-#[async_trait]
 impl QueueConsumer for RabbitMqConsumer {
     type Payload = Vec<u8>;
 

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -120,7 +120,7 @@ impl QueueBackend for RabbitMqBackend {
             .await
             .map_err(QueueError::generic)?;
 
-        Ok(producer(&conn, cfg.clone(), custom_encoders).await?)
+        producer(&conn, cfg.clone(), custom_encoders).await
     }
 
     async fn consuming_half(
@@ -131,7 +131,7 @@ impl QueueBackend for RabbitMqBackend {
             .await
             .map_err(QueueError::generic)?;
 
-        Ok(consumer(&conn, cfg.clone(), custom_decoders).await?)
+        consumer(&conn, cfg.clone(), custom_decoders).await
     }
 }
 

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -267,7 +267,7 @@ impl QueueConsumer for RabbitMqConsumer {
     }
 }
 
-pub struct RabbitMqAcker {
+struct RabbitMqAcker {
     acker: Option<LapinAcker>,
     requeue_on_nack: bool,
 }

--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -87,7 +87,6 @@ pub type RedisClusterQueueBackend = RedisQueueBackend<RedisClusterConnectionMana
 
 type RawPayload = Vec<u8>;
 
-#[async_trait]
 impl<R> QueueBackend for RedisQueueBackend<R>
 where
     R: RedisConnection,
@@ -565,7 +564,6 @@ pub struct RedisStreamProducer<M: ManageConnection> {
     _background_tasks: Arc<JoinSet<Result<(), QueueError>>>,
 }
 
-#[async_trait]
 impl<M> QueueProducer for RedisStreamProducer<M>
 where
     M: ManageConnection,
@@ -623,7 +621,6 @@ fn from_delayed_queue_key(key: &str) -> Result<RawPayload, QueueError> {
     .map_err(QueueError::generic)
 }
 
-#[async_trait]
 impl<M> ScheduledProducer for RedisStreamProducer<M>
 where
     M: ManageConnection,
@@ -691,7 +688,6 @@ where
     }
 }
 
-#[async_trait]
 impl<M> QueueConsumer for RedisStreamConsumer<M>
 where
     M: ManageConnection,

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -292,11 +292,10 @@ impl QueueConsumer for SqsQueueConsumer {
             .await
             .map_err(QueueError::generic)?;
 
-        Ok(out
-            .messages()
+        out.messages()
             .unwrap_or_default()
             .iter()
             .map(|message| -> Result<Delivery, QueueError> { Ok(self.wrap_message(message)) })
-            .collect::<Result<Vec<_>, _>>()?)
+            .collect::<Result<Vec<_>, _>>()
     }
 }

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -23,7 +23,6 @@ pub struct SqsConfig {
 
 pub struct SqsQueueBackend;
 
-#[async_trait]
 impl QueueBackend for SqsQueueBackend {
     type PayloadIn = String;
 
@@ -195,7 +194,6 @@ pub struct SqsQueueProducer {
     queue_dsn: String,
 }
 
-#[async_trait]
 impl QueueProducer for SqsQueueProducer {
     type Payload = String;
 
@@ -216,7 +214,6 @@ impl QueueProducer for SqsQueueProducer {
     }
 }
 
-#[async_trait]
 impl ScheduledProducer for SqsQueueProducer {
     async fn send_raw_scheduled(
         &self,
@@ -257,7 +254,6 @@ impl SqsQueueConsumer {
     }
 }
 
-#[async_trait]
 impl QueueConsumer for SqsQueueConsumer {
     type Payload = String;
 

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -143,7 +143,7 @@ impl QueueBackend for SqsQueueBackend {
     }
 }
 
-pub struct SqsAcker {
+struct SqsAcker {
     ack_client: Client,
     // FIXME: Cow/Arc this stuff?
     queue_dsn: String,

--- a/omniqueue/src/queue/consumer.rs
+++ b/omniqueue/src/queue/consumer.rs
@@ -1,94 +1,101 @@
-use async_trait::async_trait;
-use std::time::Duration;
+use std::{future::Future, pin::Pin, time::Duration};
 
 use crate::{decoding::DecoderRegistry, QueueError, QueuePayload};
 
 use super::Delivery;
 
-#[async_trait]
 pub trait QueueConsumer: Send + Sync {
     type Payload: QueuePayload;
 
-    async fn receive(&mut self) -> Result<Delivery, QueueError>;
+    fn receive(&mut self) -> impl Future<Output = Result<Delivery, QueueError>> + Send;
 
-    async fn receive_all(
+    fn receive_all(
         &mut self,
         max_messages: usize,
         deadline: Duration,
-    ) -> Result<Vec<Delivery>, QueueError>;
+    ) -> impl Future<Output = Result<Vec<Delivery>, QueueError>> + Send;
 
     fn into_dyn(self, custom_decoders: DecoderRegistry<Vec<u8>>) -> DynConsumer
     where
         Self: 'static + Sized,
     {
-        let c = DynConsumerInner {
-            inner: self,
-            custom_decoders,
-        };
-        DynConsumer(Box::new(c))
+        DynConsumer::new(self, custom_decoders)
     }
 }
 
-struct DynConsumerInner<T: QueuePayload, C: 'static + QueueConsumer<Payload = T>> {
+pub struct DynConsumer(Box<dyn ErasedQueueConsumer>);
+
+impl DynConsumer {
+    fn new(inner: impl QueueConsumer + 'static, custom_decoders: DecoderRegistry<Vec<u8>>) -> Self {
+        let c = DynConsumerInner {
+            inner,
+            custom_decoders,
+        };
+        Self(Box::new(c))
+    }
+}
+
+trait ErasedQueueConsumer: Send + Sync {
+    fn receive(
+        &mut self,
+    ) -> Pin<Box<dyn Future<Output = Result<Delivery, QueueError>> + Send + '_>>;
+    fn receive_all(
+        &mut self,
+        max_messages: usize,
+        deadline: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Delivery>, QueueError>> + Send + '_>>;
+}
+
+struct DynConsumerInner<C> {
     inner: C,
     custom_decoders: DecoderRegistry<Vec<u8>>,
 }
 
-#[async_trait]
-impl<T: QueuePayload, C: 'static + QueueConsumer<Payload = T>> QueueConsumer
-    for DynConsumerInner<T, C>
-{
-    type Payload = Vec<u8>;
-
-    async fn receive(&mut self) -> Result<Delivery, QueueError> {
-        let mut t_payload = self.inner.receive().await?;
-        let bytes_payload: Option<Vec<u8>> = match t_payload.payload_custom() {
-            Ok(b) => b,
-            Err(QueueError::NoDecoderForThisType) => t_payload.take_payload(),
-            Err(e) => return Err(e),
-        };
-
-        Ok(Delivery {
-            payload: bytes_payload,
-            decoders: self.custom_decoders.clone(),
-            acker: t_payload.acker,
-        })
-    }
-
-    async fn receive_all(
+impl<C: QueueConsumer> ErasedQueueConsumer for DynConsumerInner<C> {
+    fn receive(
         &mut self,
-        max_messages: usize,
-        deadline: Duration,
-    ) -> Result<Vec<Delivery>, QueueError> {
-        let xs = self.inner.receive_all(max_messages, deadline).await?;
-        let mut out = Vec::with_capacity(xs.len());
-        for mut t_payload in xs {
+    ) -> Pin<Box<dyn Future<Output = Result<Delivery, QueueError>> + Send + '_>> {
+        Box::pin(async move {
+            let mut t_payload = self.inner.receive().await?;
             let bytes_payload: Option<Vec<u8>> = match t_payload.payload_custom() {
                 Ok(b) => b,
                 Err(QueueError::NoDecoderForThisType) => t_payload.take_payload(),
                 Err(e) => return Err(e),
             };
-            out.push(Delivery {
+
+            Ok(Delivery {
                 payload: bytes_payload,
                 decoders: self.custom_decoders.clone(),
                 acker: t_payload.acker,
-            });
-        }
-        Ok(out)
+            })
+        })
     }
 
-    fn into_dyn(mut self, custom_decoders: DecoderRegistry<Vec<u8>>) -> DynConsumer
-    where
-        Self: Sized,
-    {
-        self.custom_decoders = custom_decoders;
-        DynConsumer(Box::new(self))
+    fn receive_all(
+        &mut self,
+        max_messages: usize,
+        deadline: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Delivery>, QueueError>> + Send + '_>> {
+        Box::pin(async move {
+            let xs = self.inner.receive_all(max_messages, deadline).await?;
+            let mut out = Vec::with_capacity(xs.len());
+            for mut t_payload in xs {
+                let bytes_payload: Option<Vec<u8>> = match t_payload.payload_custom() {
+                    Ok(b) => b,
+                    Err(QueueError::NoDecoderForThisType) => t_payload.take_payload(),
+                    Err(e) => return Err(e),
+                };
+                out.push(Delivery {
+                    payload: bytes_payload,
+                    decoders: self.custom_decoders.clone(),
+                    acker: t_payload.acker,
+                });
+            }
+            Ok(out)
+        })
     }
 }
 
-pub struct DynConsumer(Box<dyn QueueConsumer<Payload = Vec<u8>>>);
-
-#[async_trait]
 impl QueueConsumer for DynConsumer {
     type Payload = Vec<u8>;
 

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -132,7 +132,7 @@ impl fmt::Debug for Delivery {
 }
 
 #[async_trait]
-pub trait Acker: Send + Sync {
+pub(crate) trait Acker: Send + Sync {
     async fn ack(&mut self) -> Result<(), QueueError>;
     async fn nack(&mut self) -> Result<(), QueueError>;
 }

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::{any::TypeId, collections::HashMap, marker::PhantomData, sync::Arc};
+use std::{any::TypeId, collections::HashMap, fmt, future::Future, marker::PhantomData, sync::Arc};
 
 use async_trait::async_trait;
 use serde::de::DeserializeOwned;
@@ -21,7 +20,6 @@ pub mod producer;
 /// A marker trait with utility functions meant for the creation of new producers and/or consumers.
 ///
 /// This trait is meant to be implemented on an empty struct representing the backend as a whole.
-#[async_trait]
 pub trait QueueBackend {
     type PayloadIn: QueuePayload;
     type PayloadOut: QueuePayload;
@@ -31,21 +29,21 @@ pub trait QueueBackend {
 
     type Config;
 
-    async fn new_pair(
+    fn new_pair(
         config: Self::Config,
         custom_encoders: EncoderRegistry<Self::PayloadIn>,
         custom_decoders: DecoderRegistry<Self::PayloadOut>,
-    ) -> Result<(Self::Producer, Self::Consumer), QueueError>;
+    ) -> impl Future<Output = Result<(Self::Producer, Self::Consumer), QueueError>> + Send;
 
-    async fn producing_half(
+    fn producing_half(
         config: Self::Config,
         custom_encoders: EncoderRegistry<Self::PayloadIn>,
-    ) -> Result<Self::Producer, QueueError>;
+    ) -> impl Future<Output = Result<Self::Producer, QueueError>> + Send;
 
-    async fn consuming_half(
+    fn consuming_half(
         config: Self::Config,
         custom_decoders: DecoderRegistry<Self::PayloadOut>,
-    ) -> Result<Self::Consumer, QueueError>;
+    ) -> impl Future<Output = Result<Self::Consumer, QueueError>> + Send;
 
     fn builder(config: Self::Config) -> QueueBuilder<Self, Static>
     where

--- a/omniqueue/src/queue/producer.rs
+++ b/omniqueue/src/queue/producer.rs
@@ -1,9 +1,10 @@
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
+    future::Future,
+    pin::Pin,
 };
 
-use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::{
@@ -11,90 +12,112 @@ use crate::{
     QueueError, QueuePayload,
 };
 
-#[async_trait]
 pub trait QueueProducer: 'static + Send + Sync {
     type Payload: QueuePayload;
 
     fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Self::Payload>>>;
 
-    async fn send_raw(&self, payload: &Self::Payload) -> Result<(), QueueError>;
+    fn send_raw(
+        &self,
+        payload: &Self::Payload,
+    ) -> impl Future<Output = Result<(), QueueError>> + Send;
 
-    async fn send_bytes(&self, payload: &[u8]) -> Result<(), QueueError> {
-        let payload = Self::Payload::from_bytes_naive(payload)?;
-        self.send_raw(&payload).await
+    fn send_bytes(&self, payload: &[u8]) -> impl Future<Output = Result<(), QueueError>> + Send {
+        async move {
+            let payload = Self::Payload::from_bytes_naive(payload)?;
+            self.send_raw(&payload).await
+        }
     }
 
-    async fn send_serde_json<P: Serialize + Sync>(&self, payload: &P) -> Result<(), QueueError>
+    fn send_serde_json<P: Serialize + Sync>(
+        &self,
+        payload: &P,
+    ) -> impl Future<Output = Result<(), QueueError>> + Send
     where
         Self: Sized,
     {
-        let payload = serde_json::to_vec(payload)?;
-        self.send_bytes(&payload).await
+        async move {
+            let payload = serde_json::to_vec(payload)?;
+            self.send_bytes(&payload).await
+        }
     }
 
-    async fn send_custom<P: 'static + Send + Sync>(&self, payload: &P) -> Result<(), QueueError>
+    fn send_custom<P: 'static + Send + Sync>(
+        &self,
+        payload: &P,
+    ) -> impl Future<Output = Result<(), QueueError>> + Send
     where
         Self: Sized,
     {
-        let encoder = self
-            .get_custom_encoders()
-            .get(&TypeId::of::<P>())
-            .ok_or(QueueError::NoEncoderForThisType)?;
-        let payload = encoder.encode(payload)?;
-        self.send_raw(&payload).await
+        async move {
+            let encoder = self
+                .get_custom_encoders()
+                .get(&TypeId::of::<P>())
+                .ok_or(QueueError::NoEncoderForThisType)?;
+            let payload = encoder.encode(payload)?;
+            self.send_raw(&payload).await
+        }
     }
 
     fn into_dyn(self, custom_encoders: EncoderRegistry<Vec<u8>>) -> DynProducer
     where
         Self: Sized,
     {
-        let dyn_inner = DynProducerInner {
-            inner: self,
-            custom_encoders,
-        };
-        DynProducer(Box::new(dyn_inner))
+        DynProducer::new(self, custom_encoders)
     }
 }
 
-struct DynProducerInner<T: QueuePayload, P: QueueProducer<Payload = T>> {
+pub struct DynProducer(Box<dyn ErasedQueueProducer>);
+
+impl DynProducer {
+    fn new(inner: impl QueueProducer, custom_encoders: EncoderRegistry<Vec<u8>>) -> Self {
+        let dyn_inner = DynProducerInner {
+            inner,
+            custom_encoders,
+        };
+        Self(Box::new(dyn_inner))
+    }
+}
+
+pub(crate) trait ErasedQueueProducer: Send + Sync {
+    #[allow(clippy::ptr_arg)] // for now
+    fn send_raw<'a>(
+        &'a self,
+        payload: &'a Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send + 'a>>;
+    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Vec<u8>>>>;
+}
+
+struct DynProducerInner<P> {
     inner: P,
     custom_encoders: EncoderRegistry<Vec<u8>>,
 }
 
-#[async_trait]
-impl<T: QueuePayload, P: QueueProducer<Payload = T>> QueueProducer for DynProducerInner<T, P> {
-    type Payload = Vec<u8>;
-
-    async fn send_raw(&self, payload: &Vec<u8>) -> Result<(), QueueError> {
-        // Prioritize a custom encoder that takes a &[u8].
-        if let Some(encoder) = self
-            .inner
-            .get_custom_encoders()
-            .get(&TypeId::of::<Vec<u8>>())
-        {
-            let payload = encoder.encode(payload as &(dyn Any + Send + Sync))?;
-            self.inner.send_raw(&payload).await
-        } else {
-            self.inner.send_bytes(payload).await
-        }
+impl<P: QueueProducer> ErasedQueueProducer for DynProducerInner<P> {
+    fn send_raw<'a>(
+        &'a self,
+        payload: &'a Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Prioritize a custom encoder that takes a &[u8].
+            if let Some(encoder) = self
+                .inner
+                .get_custom_encoders()
+                .get(&TypeId::of::<Vec<u8>>())
+            {
+                let payload = encoder.encode(payload as &(dyn Any + Send + Sync))?;
+                self.inner.send_raw(&payload).await
+            } else {
+                self.inner.send_bytes(payload).await
+            }
+        })
     }
 
-    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Self::Payload>>> {
+    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Vec<u8>>>> {
         self.custom_encoders.as_ref()
-    }
-
-    fn into_dyn(mut self, custom_encoders: EncoderRegistry<Vec<u8>>) -> DynProducer
-    where
-        Self: Sized,
-    {
-        self.custom_encoders = custom_encoders;
-        DynProducer(Box::new(self))
     }
 }
 
-pub struct DynProducer(pub(crate) Box<dyn QueueProducer<Payload = Vec<u8>>>);
-
-#[async_trait]
 impl QueueProducer for DynProducer {
     type Payload = Vec<u8>;
 

--- a/omniqueue/src/scheduled/mod.rs
+++ b/omniqueue/src/scheduled/mod.rs
@@ -1,162 +1,160 @@
 use std::{
     any::{Any, TypeId},
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
     time::Duration,
 };
 
-use async_trait::async_trait;
 use serde::Serialize;
 
 use crate::{
-    encoding::EncoderRegistry,
+    encoding::{CustomEncoder, EncoderRegistry},
     queue::{
-        producer::{DynProducer, QueueProducer},
+        producer::{ErasedQueueProducer, QueueProducer},
         QueueBackend,
     },
     QueueError, QueuePayload,
 };
 
 // FIXME(onelson): only used by redis -- is this meant to be called internally or by the caller building the backend?
-#[async_trait]
 pub trait SchedulerBackend: QueueBackend {
-    async fn start_scheduler_background_task(
+    fn start_scheduler_background_task(
         &self,
-    ) -> Option<tokio::task::JoinHandle<Result<(), QueueError>>>;
+    ) -> impl Future<Output = Option<tokio::task::JoinHandle<Result<(), QueueError>>>> + Send;
 }
 
-#[async_trait]
 pub trait ScheduledProducer: QueueProducer {
-    async fn send_raw_scheduled(
+    fn send_raw_scheduled(
         &self,
         payload: &Self::Payload,
         delay: Duration,
-    ) -> Result<(), QueueError>;
+    ) -> impl Future<Output = Result<(), QueueError>> + Send;
 
-    async fn send_bytes_scheduled(
+    fn send_bytes_scheduled(
         &self,
         payload: &[u8],
         delay: Duration,
-    ) -> Result<(), QueueError> {
-        let payload = Self::Payload::from_bytes_naive(payload)?;
-        self.send_raw_scheduled(&payload, delay).await
+    ) -> impl Future<Output = Result<(), QueueError>> + Send {
+        async move {
+            let payload = Self::Payload::from_bytes_naive(payload)?;
+            self.send_raw_scheduled(&payload, delay).await
+        }
     }
 
-    async fn send_serde_json_scheduled<P: Serialize + Sync>(
+    fn send_serde_json_scheduled<P: Serialize + Sync>(
         &self,
         payload: &P,
         delay: Duration,
-    ) -> Result<(), QueueError>
+    ) -> impl Future<Output = Result<(), QueueError>> + Send
     where
         Self: Sized,
     {
-        let payload = serde_json::to_vec(payload)?;
-        self.send_bytes_scheduled(&payload, delay).await
+        async move {
+            let payload = serde_json::to_vec(payload)?;
+            self.send_bytes_scheduled(&payload, delay).await
+        }
     }
 
-    async fn send_custom_scheduled<P: 'static + Send + Sync>(
+    fn send_custom_scheduled<P: 'static + Send + Sync>(
         &self,
         payload: &P,
         delay: Duration,
-    ) -> Result<(), QueueError>
+    ) -> impl Future<Output = Result<(), QueueError>> + Send
     where
         Self: Sized,
     {
-        let encoder = self
-            .get_custom_encoders()
-            .get(&TypeId::of::<P>())
-            .ok_or(QueueError::NoEncoderForThisType)?;
+        async move {
+            let encoder = self
+                .get_custom_encoders()
+                .get(&TypeId::of::<P>())
+                .ok_or(QueueError::NoEncoderForThisType)?;
 
-        let payload = encoder.encode(payload)?;
-        self.send_raw_scheduled(&payload, delay).await
+            let payload = encoder.encode(payload)?;
+            self.send_raw_scheduled(&payload, delay).await
+        }
     }
 
     fn into_dyn_scheduled(self, custom_encoders: EncoderRegistry<Vec<u8>>) -> DynScheduledProducer
     where
         Self: Sized,
     {
-        let dyn_inner = DynScheduledProducerInner {
-            inner: self,
-            custom_encoders,
-        };
-        DynScheduledProducer(Box::new(dyn_inner))
+        DynScheduledProducer::new(self, custom_encoders)
     }
 }
 
-struct DynScheduledProducerInner<T: QueuePayload, P: ScheduledProducer<Payload = T>> {
+pub struct DynScheduledProducer(Box<dyn ErasedScheduledProducer>);
+
+impl DynScheduledProducer {
+    fn new(inner: impl ScheduledProducer, custom_encoders: EncoderRegistry<Vec<u8>>) -> Self {
+        let dyn_inner = DynScheduledProducerInner {
+            inner,
+            custom_encoders,
+        };
+        Self(Box::new(dyn_inner))
+    }
+}
+
+trait ErasedScheduledProducer: ErasedQueueProducer {
+    #[allow(clippy::ptr_arg)] // for now
+    fn send_raw_scheduled<'a>(
+        &'a self,
+        payload: &'a Vec<u8>,
+        delay: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send + 'a>>;
+}
+
+struct DynScheduledProducerInner<P> {
     inner: P,
     custom_encoders: EncoderRegistry<Vec<u8>>,
 }
 
-#[async_trait]
-impl<T: QueuePayload, P: ScheduledProducer<Payload = T>> QueueProducer
-    for DynScheduledProducerInner<T, P>
-{
-    type Payload = Vec<u8>;
-
-    async fn send_raw(&self, payload: &Vec<u8>) -> Result<(), QueueError> {
-        if let Some(encoder) = self
-            .inner
-            .get_custom_encoders()
-            .get(&TypeId::of::<Vec<u8>>())
-        {
-            let payload = encoder.encode(payload as &(dyn Any + Send + Sync))?;
-            self.inner.send_raw(&payload).await
-        } else {
-            self.inner.send_bytes(payload).await
-        }
+impl<P: ScheduledProducer> ErasedQueueProducer for DynScheduledProducerInner<P> {
+    fn send_raw<'a>(
+        &'a self,
+        payload: &'a Vec<u8>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Prioritize a custom encoder that takes a &[u8].
+            if let Some(encoder) = self
+                .inner
+                .get_custom_encoders()
+                .get(&TypeId::of::<Vec<u8>>())
+            {
+                let payload = encoder.encode(payload as &(dyn Any + Send + Sync))?;
+                self.inner.send_raw(&payload).await
+            } else {
+                self.inner.send_bytes(payload).await
+            }
+        })
     }
 
-    fn get_custom_encoders(
-        &self,
-    ) -> &std::collections::HashMap<TypeId, Box<dyn crate::encoding::CustomEncoder<Self::Payload>>>
-    {
+    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Vec<u8>>>> {
         self.custom_encoders.as_ref()
     }
-
-    fn into_dyn(mut self, custom_encoders: EncoderRegistry<Vec<u8>>) -> DynProducer
-    where
-        Self: Sized,
-    {
-        self.custom_encoders = custom_encoders;
-        DynProducer(Box::new(self))
-    }
 }
 
-#[async_trait]
-impl<T: QueuePayload, P: ScheduledProducer<Payload = T>> ScheduledProducer
-    for DynScheduledProducerInner<T, P>
-{
-    async fn send_raw_scheduled(
-        &self,
-        payload: &Vec<u8>,
+impl<P: ScheduledProducer> ErasedScheduledProducer for DynScheduledProducerInner<P> {
+    fn send_raw_scheduled<'a>(
+        &'a self,
+        payload: &'a Vec<u8>,
         delay: Duration,
-    ) -> Result<(), QueueError> {
-        if let Some(encoder) = self
-            .inner
-            .get_custom_encoders()
-            .get(&TypeId::of::<Vec<u8>>())
-        {
-            let payload = encoder.encode(payload as &(dyn Any + Send + Sync))?;
-            self.inner.send_raw(&payload).await
-        } else {
-            self.inner.send_bytes_scheduled(payload, delay).await
-        }
-    }
-
-    fn into_dyn_scheduled(
-        mut self,
-        custom_encoders: EncoderRegistry<Vec<u8>>,
-    ) -> DynScheduledProducer
-    where
-        Self: Sized,
-    {
-        self.custom_encoders = custom_encoders;
-        DynScheduledProducer(Box::new(self))
+    ) -> Pin<Box<dyn Future<Output = Result<(), QueueError>> + Send + 'a>> {
+        Box::pin(async move {
+            if let Some(encoder) = self
+                .inner
+                .get_custom_encoders()
+                .get(&TypeId::of::<Vec<u8>>())
+            {
+                let payload = encoder.encode(payload as &(dyn Any + Send + Sync))?;
+                self.inner.send_raw(&payload).await
+            } else {
+                self.inner.send_bytes_scheduled(payload, delay).await
+            }
+        })
     }
 }
 
-pub struct DynScheduledProducer(Box<dyn ScheduledProducer<Payload = Vec<u8>>>);
-
-#[async_trait]
 impl QueueProducer for DynScheduledProducer {
     type Payload = Vec<u8>;
 
@@ -164,15 +162,11 @@ impl QueueProducer for DynScheduledProducer {
         self.0.send_raw(payload).await
     }
 
-    fn get_custom_encoders(
-        &self,
-    ) -> &std::collections::HashMap<TypeId, Box<dyn crate::encoding::CustomEncoder<Self::Payload>>>
-    {
+    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Self::Payload>>> {
         self.0.get_custom_encoders()
     }
 }
 
-#[async_trait]
 impl ScheduledProducer for DynScheduledProducer {
     async fn send_raw_scheduled(
         &self,
@@ -199,16 +193,12 @@ pub struct SplitScheduledProducer<
     scheduled: S,
 }
 
-#[async_trait]
 impl<T: QueuePayload, P: QueueProducer<Payload = T>, S: ScheduledProducer<Payload = T>>
     QueueProducer for SplitScheduledProducer<T, P, S>
 {
     type Payload = T;
 
-    fn get_custom_encoders(
-        &self,
-    ) -> &std::collections::HashMap<TypeId, Box<dyn crate::encoding::CustomEncoder<Self::Payload>>>
-    {
+    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Self::Payload>>> {
         self.unscheduled.get_custom_encoders()
     }
 
@@ -217,7 +207,6 @@ impl<T: QueuePayload, P: QueueProducer<Payload = T>, S: ScheduledProducer<Payloa
     }
 }
 
-#[async_trait]
 impl<T: QueuePayload, P: QueueProducer<Payload = T>, S: ScheduledProducer<Payload = T>>
     ScheduledProducer for SplitScheduledProducer<T, P, S>
 {


### PR DESCRIPTION
… for our own public traits. This is primarily a docs improvement, but also removes unnecessary boxing of futures.

Details about the funny abbreviations: https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html

Before:

![Screenshot 2024-02-16 at 12-38-09 QueueProducer in omniqueue queue producer - Rust](https://github.com/svix/omniqueue-rs/assets/158304798/312ec227-e42e-4f0f-b3f9-10a16dab6779)

After:

![Screenshot 2024-02-16 at 12-38-40 QueueProducer in omniqueue queue producer - Rust](https://github.com/svix/omniqueue-rs/assets/158304798/ed70db18-ae4e-4c37-af95-bf1b094da0b1)
