### PR TITLE
Normalize type names in backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ While the exact configuration will depend on the backend used, usage is roughly 
        queue_dsn: "http://localhost:9324/queue/queue_name".to_owned(),
        override_endpoint: true,
    };
-   let (producer, mut consumer) = SqsQueueBackend::builder(cfg).build_pair().await?;
+   let (producer, mut consumer) = SqsBackend::builder(cfg).build_pair().await?;
 
    producer.send_serde_json(&ExampleType::default()).await?;
 
@@ -60,7 +60,7 @@ While the exact configuration will depend on the backend used, usage is roughly 
        queue_dsn: "http://localhost:9324/queue/queue_name".to_owned(),
        override_endpoint: true,
    };
-   let (producer, mut consumer) = SqsQueueBackend::builder(cfg)
+   let (producer, mut consumer) = SqsBackend::builder(cfg)
        .make_dynamic()
        .build_pair()
        .await?;

--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -37,14 +37,14 @@ tokio-executor-trait = "2.1"
 tokio-reactor-trait = "1.1"
 
 [features]
-default = ["memory_queue", "gcp_pubsub", "rabbitmq", "redis", "redis_cluster", "sqs"]
+default = ["in_memory", "gcp_pubsub", "rabbitmq", "redis", "redis_cluster", "sqs"]
+in_memory = []
 gcp_pubsub = [
     "dep:futures-util",
     "dep:google-cloud-googleapis",
     "dep:google-cloud-pubsub",
     "dep:tokio-util",
 ]
-memory_queue = []
 rabbitmq = ["dep:futures-util", "dep:lapin"]
 redis = ["dep:bb8", "dep:bb8-redis", "dep:redis", "dep:svix-ksuid"]
 redis_cluster = ["redis", "redis/cluster-async"]

--- a/omniqueue/src/backends/mod.rs
+++ b/omniqueue/src/backends/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "gcp_pubsub")]
 pub mod gcp_pubsub;
-#[cfg(feature = "memory_queue")]
-pub mod memory_queue;
+#[cfg(feature = "in_memory")]
+pub mod in_memory;
 #[cfg(feature = "rabbitmq")]
 pub mod rabbitmq;
 #[cfg(feature = "redis")]

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -90,11 +90,11 @@ async fn producer(
 
 impl QueueBackend for RabbitMqBackend {
     type PayloadIn = Vec<u8>;
-
     type PayloadOut = Vec<u8>;
-    type Producer = RabbitMqProducer;
 
+    type Producer = RabbitMqProducer;
     type Consumer = RabbitMqConsumer;
+
     type Config = RabbitMqConfig;
 
     async fn new_pair(

--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -49,7 +49,7 @@ use crate::{
 #[cfg(feature = "redis_cluster")]
 mod cluster;
 #[cfg(feature = "redis_cluster")]
-use cluster::RedisClusterConnectionManager;
+pub use cluster::RedisClusterConnectionManager;
 
 pub trait RedisConnection
 where
@@ -99,11 +99,11 @@ where
 {
     // FIXME: Is it possible to use the types Redis actually uses?
     type PayloadIn = RawPayload;
-
     type PayloadOut = RawPayload;
-    type Producer = RedisStreamProducer<R>;
 
+    type Producer = RedisStreamProducer<R>;
     type Consumer = RedisStreamConsumer<R>;
+
     type Config = RedisConfig;
 
     async fn new_pair(
@@ -256,7 +256,7 @@ where
             let payload_key = payload_key.to_string();
             tracing::debug!(
                 "spawning delayed task scheduler: delayed_queue_key=`{delayed_queue_key}`, \
-            delayed_lock=`{delayed_lock}`"
+                 delayed_lock=`{delayed_lock}`"
             );
 
             async move {
@@ -516,7 +516,7 @@ where
     Ok(())
 }
 
-pub struct RedisStreamAcker<M: ManageConnection> {
+struct RedisStreamAcker<M: ManageConnection> {
     redis: bb8::Pool<M>,
     queue_key: String,
     consumer_group: String,

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -31,7 +31,7 @@
 //! ```no_run
 //! # async {
 //! use omniqueue::{
-//!     backends::sqs::{SqsConfig, SqsQueueBackend},
+//!     backends::sqs::{SqsConfig, SqsBackend},
 //!     queue::QueueBackend,
 //! };
 //!
@@ -41,11 +41,11 @@
 //! };
 //!
 //! // Either both producer and consumer
-//! let (p, mut c) = SqsQueueBackend::builder(cfg.clone()).build_pair().await?;
+//! let (p, mut c) = SqsBackend::builder(cfg.clone()).build_pair().await?;
 //!
 //! // Or one half
-//! let p = SqsQueueBackend::builder(cfg.clone()).build_producer().await?;
-//! let mut c = SqsQueueBackend::builder(cfg).build_consumer().await?;
+//! let p = SqsBackend::builder(cfg.clone()).build_producer().await?;
+//! let mut c = SqsBackend::builder(cfg).build_consumer().await?;
 //! # anyhow::Ok(())
 //! # };
 //! ```
@@ -54,14 +54,14 @@
 //!
 //! ```no_run
 //! # use omniqueue::{
-//! #     backends::sqs::SqsQueueBackend,
+//! #     backends::sqs::SqsBackend,
 //! #     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend},
 //! # };
 //! # async {
 //! # #[derive(Default, serde::Deserialize, serde::Serialize)]
 //! # struct ExampleType;
 //! #
-//! # let (p, mut c) = SqsQueueBackend::builder(todo!()).build_pair().await?;
+//! # let (p, mut c) = SqsBackend::builder(todo!()).build_pair().await?;
 //! p.send_serde_json(&ExampleType::default()).await?;
 //!
 //! let delivery = c.receive().await?;

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -15,13 +15,11 @@
 //! Each backend is enabled with its associated cargo feature. All backends are enabled by default.
 //! As of present it supports:
 //!
-//!   * In-memory queues
-//!
-//!   * RabbitMQ
-//!
-//!   * Redis streams
-//!
-//!   * SQS
+//! * In-memory queue
+//! * Google Cloud Pub/Sub
+//! * RabbitMQ
+//! * Redis
+//! * Amazon SQS
 //!
 //! ## How to Use Omniqueue
 //!

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -1,5 +1,5 @@
 use omniqueue::{
-    backends::redis::{RedisConfig, RedisQueueBackend},
+    backends::redis::{RedisBackend, RedisConfig},
     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend, QueueBuilder, Static},
     scheduled::ScheduledProducer,
 };
@@ -25,7 +25,7 @@ impl Drop for RedisStreamDrop {
 /// such as to ensure there is no stealing
 ///
 /// This will also return a [`RedisStreamDrop`] to clean up the stream after the test ends.
-async fn make_test_queue() -> (QueueBuilder<RedisQueueBackend, Static>, RedisStreamDrop) {
+async fn make_test_queue() -> (QueueBuilder<RedisBackend, Static>, RedisStreamDrop) {
     let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
         .take(8)
         .collect();
@@ -50,10 +50,7 @@ async fn make_test_queue() -> (QueueBuilder<RedisQueueBackend, Static>, RedisStr
         ack_deadline_ms: 5_000,
     };
 
-    (
-        RedisQueueBackend::builder(config),
-        RedisStreamDrop(stream_name),
-    )
+    (RedisBackend::builder(config), RedisStreamDrop(stream_name))
 }
 
 #[tokio::test]

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -1,5 +1,5 @@
 use omniqueue::{
-    backends::redis::{RedisClusterQueueBackend, RedisConfig},
+    backends::redis::{RedisClusterBackend, RedisConfig},
     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend, QueueBuilder, Static},
     scheduled::ScheduledProducer,
 };
@@ -25,10 +25,7 @@ impl Drop for RedisStreamDrop {
 /// such as to ensure there is no stealing
 ///
 /// This will also return a [`RedisStreamDrop`] to clean up the stream after the test ends.
-async fn make_test_queue() -> (
-    QueueBuilder<RedisClusterQueueBackend, Static>,
-    RedisStreamDrop,
-) {
+async fn make_test_queue() -> (QueueBuilder<RedisClusterBackend, Static>, RedisStreamDrop) {
     let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
         .take(8)
         .collect();
@@ -54,7 +51,7 @@ async fn make_test_queue() -> (
     };
 
     (
-        RedisClusterQueueBackend::builder(config),
+        RedisClusterBackend::builder(config),
         RedisStreamDrop(stream_name),
     )
 }

--- a/omniqueue/tests/it/sqs.rs
+++ b/omniqueue/tests/it/sqs.rs
@@ -1,6 +1,6 @@
 use aws_sdk_sqs::Client;
 use omniqueue::{
-    backends::sqs::{SqsConfig, SqsQueueBackend},
+    backends::sqs::{SqsBackend, SqsConfig},
     queue::{consumer::QueueConsumer, producer::QueueProducer, QueueBackend, QueueBuilder, Static},
     scheduled::ScheduledProducer,
 };
@@ -19,7 +19,7 @@ const DEFAULT_CFG: [(&str, &str); 3] = [
 ///
 /// Additionally this will make a temporary queue on that instance for the duration of the test such
 /// as to ensure there is no stealing.w
-async fn make_test_queue() -> QueueBuilder<SqsQueueBackend, Static> {
+async fn make_test_queue() -> QueueBuilder<SqsBackend, Static> {
     for (var, val) in &DEFAULT_CFG {
         if std::env::var(var).is_err() {
             std::env::set_var(var, val);
@@ -44,7 +44,7 @@ async fn make_test_queue() -> QueueBuilder<SqsQueueBackend, Static> {
         override_endpoint: true,
     };
 
-    SqsQueueBackend::builder(config)
+    SqsBackend::builder(config)
 }
 
 #[tokio::test]


### PR DESCRIPTION
I'm not so sure about redis, maybe that one should keep the "Stream" naming? But if so, it should be applied consistently.