### PR TITLE
Change the raw payload type to be String, always

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,10 @@ struct ExampleType {
 
 
 let (p, mut c) = RabbitMqBackend::builder(cfg)
-	// RabbitMQ's internal representation is an arbitrary byte array.
-	.with_encoder(|et: &ExampleType| -> omniqueue::Result<Vec<u8>> {
+	.with_encoder(|et: &ExampleType| -> omniqueue::Result<String> {
 		Ok(vec![et.field])
 	})
-	.with_decoder(|v: &Vec<u8>| -> omniqueue::Result<ExampleType> {
+	.with_decoder(|v: &str| -> omniqueue::Result<ExampleType> {
 		Ok(ExampleType {
 			field: *v.first().unwrap_or(&0),
 		})

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -9,7 +9,7 @@ use aws_sdk_sqs::{
 
 use crate::{
     builder::{QueueBuilder, Static},
-    decoding::{CustomDecoder, CustomDecoderStandardized, DecoderRegistry},
+    decoding::DecoderRegistry,
     encoding::{CustomEncoder, EncoderRegistry},
     queue::{Acker, Delivery, QueueBackend, QueueConsumer, QueueProducer},
     QueueError, Result, ScheduledQueueProducer,
@@ -31,9 +31,6 @@ impl SqsBackend {
 }
 
 impl QueueBackend for SqsBackend {
-    type PayloadIn = String;
-    type PayloadOut = String;
-
     type Producer = SqsProducer;
     type Consumer = SqsConsumer;
 
@@ -41,8 +38,8 @@ impl QueueBackend for SqsBackend {
 
     async fn new_pair(
         cfg: SqsConfig,
-        custom_encoders: EncoderRegistry<String>,
-        custom_decoders: DecoderRegistry<String>,
+        custom_encoders: EncoderRegistry,
+        custom_decoders: DecoderRegistry,
     ) -> Result<(SqsProducer, SqsConsumer)> {
         let aws_cfg = if cfg.override_endpoint {
             aws_config::from_env()
@@ -61,23 +58,8 @@ impl QueueBackend for SqsBackend {
             queue_dsn: cfg.queue_dsn.clone(),
         };
 
-        let byte_decoders = Arc::new(
-            custom_decoders
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        *k,
-                        Arc::new(CustomDecoderStandardized::from_decoder(
-                            v.clone(),
-                            |b: &Vec<u8>| String::from_utf8(b.clone()).map_err(QueueError::generic),
-                        )) as Arc<dyn CustomDecoder<Vec<u8>>>,
-                    )
-                })
-                .collect(),
-        );
-
         let consumer = SqsConsumer {
-            bytes_registry: byte_decoders,
+            custom_decoders,
             client,
             queue_dsn: cfg.queue_dsn,
         };
@@ -87,7 +69,7 @@ impl QueueBackend for SqsBackend {
 
     async fn producing_half(
         cfg: SqsConfig,
-        custom_encoders: EncoderRegistry<String>,
+        custom_encoders: EncoderRegistry,
     ) -> Result<SqsProducer> {
         let aws_cfg = if cfg.override_endpoint {
             aws_config::from_env()
@@ -111,7 +93,7 @@ impl QueueBackend for SqsBackend {
 
     async fn consuming_half(
         cfg: SqsConfig,
-        custom_decoders: DecoderRegistry<String>,
+        custom_decoders: DecoderRegistry,
     ) -> Result<SqsConsumer> {
         let aws_cfg = if cfg.override_endpoint {
             aws_config::from_env()
@@ -124,23 +106,8 @@ impl QueueBackend for SqsBackend {
 
         let client = Client::new(&aws_cfg);
 
-        let byte_decoders = Arc::new(
-            custom_decoders
-                .iter()
-                .map(|(k, v)| {
-                    (
-                        *k,
-                        Arc::new(CustomDecoderStandardized::from_decoder(
-                            v.clone(),
-                            |b: &Vec<u8>| String::from_utf8(b.clone()).map_err(QueueError::generic),
-                        )) as Arc<dyn CustomDecoder<Vec<u8>>>,
-                    )
-                })
-                .collect(),
-        );
-
         let consumer = SqsConsumer {
-            bytes_registry: byte_decoders,
+            custom_decoders,
             client,
             queue_dsn: cfg.queue_dsn,
         };
@@ -196,19 +163,17 @@ impl Acker for SqsAcker {
 }
 
 pub struct SqsProducer {
-    registry: Arc<HashMap<TypeId, Box<dyn CustomEncoder<String>>>>,
+    registry: Arc<HashMap<TypeId, Box<dyn CustomEncoder>>>,
     client: Client,
     queue_dsn: String,
 }
 
 impl QueueProducer for SqsProducer {
-    type Payload = String;
-
-    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder<Self::Payload>>> {
+    fn get_custom_encoders(&self) -> &HashMap<TypeId, Box<dyn CustomEncoder>> {
         self.registry.as_ref()
     }
 
-    async fn send_raw(&self, payload: &String) -> Result<()> {
+    async fn send_raw(&self, payload: &str) -> Result<()> {
         self.client
             .send_message()
             .queue_url(&self.queue_dsn)
@@ -222,7 +187,7 @@ impl QueueProducer for SqsProducer {
 }
 
 impl ScheduledQueueProducer for SqsProducer {
-    async fn send_raw_scheduled(&self, payload: &Self::Payload, delay: Duration) -> Result<()> {
+    async fn send_raw_scheduled(&self, payload: &str, delay: Duration) -> Result<()> {
         self.client
             .send_message()
             .queue_url(&self.queue_dsn)
@@ -237,7 +202,7 @@ impl ScheduledQueueProducer for SqsProducer {
 }
 
 pub struct SqsConsumer {
-    bytes_registry: DecoderRegistry<Vec<u8>>,
+    custom_decoders: DecoderRegistry,
     client: Client,
     queue_dsn: String,
 }
@@ -245,21 +210,19 @@ pub struct SqsConsumer {
 impl SqsConsumer {
     fn wrap_message(&self, message: &Message) -> Delivery {
         Delivery {
-            decoders: self.bytes_registry.clone(),
+            decoders: self.custom_decoders.clone(),
             acker: Box::new(SqsAcker {
                 ack_client: self.client.clone(),
                 queue_dsn: self.queue_dsn.clone(),
                 receipt_handle: message.receipt_handle().map(ToOwned::to_owned),
                 has_been_acked_or_nacked: false,
             }),
-            payload: Some(message.body().unwrap_or_default().as_bytes().to_owned()),
+            payload: Some(message.body().unwrap_or_default().to_owned()),
         }
     }
 }
 
 impl QueueConsumer for SqsConsumer {
-    type Payload = String;
-
     async fn receive(&mut self) -> Result<Delivery> {
         let out = self
             .client

--- a/omniqueue/src/builder.rs
+++ b/omniqueue/src/builder.rs
@@ -21,11 +21,11 @@ pub struct Dynamic;
 pub struct QueueBuilder<Q: QueueBackend, S = Static> {
     config: Q::Config,
 
-    encoders: HashMap<TypeId, Box<dyn CustomEncoder<Q::PayloadIn>>>,
-    decoders: HashMap<TypeId, Arc<dyn CustomDecoder<Q::PayloadOut>>>,
+    encoders: HashMap<TypeId, Box<dyn CustomEncoder>>,
+    decoders: HashMap<TypeId, Arc<dyn CustomDecoder>>,
 
-    encoders_bytes: HashMap<TypeId, Box<dyn CustomEncoder<Vec<u8>>>>,
-    decoders_bytes: HashMap<TypeId, Arc<dyn CustomDecoder<Vec<u8>>>>,
+    encoders_bytes: HashMap<TypeId, Box<dyn CustomEncoder>>,
+    decoders_bytes: HashMap<TypeId, Arc<dyn CustomDecoder>>,
 
     _pd: PhantomData<S>,
 }
@@ -47,14 +47,14 @@ impl<Q: QueueBackend> QueueBuilder<Q> {
         }
     }
 
-    pub fn with_encoder<I: 'static>(mut self, e: impl IntoCustomEncoder<I, Q::PayloadIn>) -> Self {
+    pub fn with_encoder<I: 'static>(mut self, e: impl IntoCustomEncoder<I>) -> Self {
         let encoder = e.into();
         self.encoders.insert(TypeId::of::<I>(), encoder);
 
         self
     }
 
-    pub fn with_decoder<O: 'static>(mut self, d: impl IntoCustomDecoder<Q::PayloadOut, O>) -> Self {
+    pub fn with_decoder<O: 'static>(mut self, d: impl IntoCustomDecoder<O>) -> Self {
         let decoder = d.into();
         self.decoders.insert(TypeId::of::<O>(), decoder);
 
@@ -91,14 +91,14 @@ impl<Q: QueueBackend> QueueBuilder<Q> {
 }
 
 impl<Q: QueueBackend + 'static> QueueBuilder<Q, Dynamic> {
-    pub fn with_bytes_encoder<I: 'static>(mut self, e: impl IntoCustomEncoder<I, Vec<u8>>) -> Self {
+    pub fn with_raw_encoder<I: 'static>(mut self, e: impl IntoCustomEncoder<I>) -> Self {
         let encoder = e.into();
         self.encoders_bytes.insert(TypeId::of::<I>(), encoder);
 
         self
     }
 
-    pub fn with_bytes_decoder<O: 'static>(mut self, d: impl IntoCustomDecoder<Vec<u8>, O>) -> Self {
+    pub fn with_raw_decoder<O: 'static>(mut self, d: impl IntoCustomDecoder<O>) -> Self {
         let decoder = d.into();
         self.decoders_bytes.insert(TypeId::of::<O>(), decoder);
 

--- a/omniqueue/src/encoding.rs
+++ b/omniqueue/src/encoding.rs
@@ -7,51 +7,47 @@ use std::{
 
 use crate::{QueueError, Result};
 
-pub type EncoderRegistry<T> = Arc<HashMap<TypeId, Box<dyn CustomEncoder<T>>>>;
+pub type EncoderRegistry = Arc<HashMap<TypeId, Box<dyn CustomEncoder>>>;
 
-pub trait CustomEncoder<P>: Send + Sync {
+pub trait CustomEncoder: Send + Sync {
     fn item_type(&self) -> TypeId;
-    fn encode(&self, item: &(dyn Any + Send + Sync)) -> Result<Box<P>>;
+    fn encode(&self, item: &(dyn Any + Send + Sync)) -> Result<String>;
 }
 
-pub trait IntoCustomEncoder<I, O> {
-    fn into(self) -> Box<dyn CustomEncoder<O>>;
+pub trait IntoCustomEncoder<I> {
+    fn into(self) -> Box<dyn CustomEncoder>;
 }
 
-struct FnEncoder<I, O, F> {
+struct FnEncoder<I, F> {
     f: F,
 
     _i_pd: PhantomData<I>,
-    _o_pd: PhantomData<O>,
 }
 
-impl<I, O, F> CustomEncoder<O> for FnEncoder<I, O, F>
+impl<I, F> CustomEncoder for FnEncoder<I, F>
 where
     I: Send + Sync + 'static,
-    O: Send + Sync + 'static,
-    F: Fn(&I) -> Result<O> + Send + Sync + 'static,
+    F: Fn(&I) -> Result<String> + Send + Sync + 'static,
 {
     fn item_type(&self) -> TypeId {
         TypeId::of::<I>()
     }
 
-    fn encode(&self, item: &(dyn Any + Send + Sync)) -> Result<Box<O>> {
+    fn encode(&self, item: &(dyn Any + Send + Sync)) -> Result<String> {
         let item: &I = item.downcast_ref().ok_or(QueueError::AnyError)?;
-        (self.f)(item).map(Box::new)
+        (self.f)(item)
     }
 }
 
-impl<I, O, F> IntoCustomEncoder<I, O> for F
+impl<I, F> IntoCustomEncoder<I> for F
 where
     I: Send + Sync + 'static,
-    O: Send + Sync + 'static,
-    F: Fn(&I) -> Result<O> + Send + Sync + 'static,
+    F: Fn(&I) -> Result<String> + Send + Sync + 'static,
 {
-    fn into(self) -> Box<dyn CustomEncoder<O>> {
+    fn into(self) -> Box<dyn CustomEncoder> {
         Box::new(FnEncoder {
             f: self,
             _i_pd: PhantomData,
-            _o_pd: PhantomData,
         })
     }
 }

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -170,12 +170,12 @@ pub enum QueueError {
 }
 
 impl QueueError {
-    pub fn generic<E: 'static + std::error::Error + Send + Sync>(e: E) -> Self {
+    pub fn generic<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
         Self::Generic(Box::new(e))
     }
 }
 
-pub trait QueuePayload: 'static + Send + Sync {
+pub trait QueuePayload: Send + Sync + 'static {
     fn to_bytes_naive(&self) -> Result<Vec<u8>>;
     fn from_bytes_naive(bytes: &[u8]) -> Result<Box<Self>>;
 }

--- a/omniqueue/src/queue/consumer.rs
+++ b/omniqueue/src/queue/consumer.rs
@@ -4,7 +4,7 @@ use crate::{decoding::DecoderRegistry, QueueError, QueuePayload, Result};
 
 use super::Delivery;
 
-pub trait QueueConsumer: Send {
+pub trait QueueConsumer: Send + Sized {
     type Payload: QueuePayload;
 
     fn receive(&mut self) -> impl Future<Output = Result<Delivery>> + Send;
@@ -17,7 +17,7 @@ pub trait QueueConsumer: Send {
 
     fn into_dyn(self, custom_decoders: DecoderRegistry<Vec<u8>>) -> DynConsumer
     where
-        Self: Sized + 'static,
+        Self: 'static,
     {
         DynConsumer::new(self, custom_decoders)
     }

--- a/omniqueue/src/scheduled/mod.rs
+++ b/omniqueue/src/scheduled/mod.rs
@@ -36,24 +36,18 @@ pub trait ScheduledQueueProducer: QueueProducer {
         &self,
         payload: &P,
         delay: Duration,
-    ) -> impl Future<Output = Result<()>> + Send
-    where
-        Self: Sized,
-    {
+    ) -> impl Future<Output = Result<()>> + Send {
         async move {
             let payload = serde_json::to_vec(payload)?;
             self.send_bytes_scheduled(&payload, delay).await
         }
     }
 
-    fn send_custom_scheduled<P: 'static + Send + Sync>(
+    fn send_custom_scheduled<P: Send + Sync + 'static>(
         &self,
         payload: &P,
         delay: Duration,
-    ) -> impl Future<Output = Result<()>> + Send
-    where
-        Self: Sized,
-    {
+    ) -> impl Future<Output = Result<()>> + Send {
         async move {
             let encoder = self
                 .get_custom_encoders()
@@ -70,7 +64,7 @@ pub trait ScheduledQueueProducer: QueueProducer {
         custom_encoders: EncoderRegistry<Vec<u8>>,
     ) -> DynScheduledQueueProducer
     where
-        Self: Sized + 'static,
+        Self: 'static,
     {
         DynScheduledQueueProducer::new(self, custom_encoders)
     }

--- a/omniqueue/tests/it/gcp_pubsub.rs
+++ b/omniqueue/tests/it/gcp_pubsub.rs
@@ -131,35 +131,23 @@ async fn make_test_queue() -> QueueBuilder<GcpPubSubBackend> {
 
 #[tokio::test]
 async fn test_raw_send_recv() {
-    let payload = b"{\"test\": \"data\"}";
+    let payload = "{\"test\": \"data\"}";
     let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
 
-    p.send_raw(&payload.to_vec()).await.unwrap();
+    p.send_raw(payload).await.unwrap();
 
     let d = c.receive().await.unwrap();
     assert_eq!(d.borrow_payload().unwrap(), payload);
-}
-
-#[tokio::test]
-async fn test_bytes_send_recv() {
-    let payload = b"hello";
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
-
-    p.send_bytes(payload).await.unwrap();
-
-    let d = c.receive().await.unwrap();
-    assert_eq!(d.borrow_payload().unwrap(), payload);
-    d.ack().await.unwrap();
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct ExType {
-    a: u8,
+    a: char,
 }
 
 #[tokio::test]
 async fn test_serde_send_recv() {
-    let payload = ExType { a: 2 };
+    let payload = ExType { a: '2' };
     let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload).await.unwrap();
@@ -171,12 +159,12 @@ async fn test_serde_send_recv() {
 
 #[tokio::test]
 async fn test_custom_send_recv() {
-    let payload = ExType { a: 3 };
+    let payload = ExType { a: '3' };
 
-    let encoder = |p: &ExType| Ok(vec![p.a]);
-    let decoder = |p: &Vec<u8>| {
+    let encoder = |p: &ExType| Ok([p.a].into_iter().collect());
+    let decoder = |p: &str| {
         Ok(ExType {
-            a: p.first().copied().unwrap_or(0),
+            a: p.chars().next().unwrap_or('\0'),
         })
     };
 
@@ -201,7 +189,7 @@ async fn test_custom_send_recv() {
 /// Consumer will return immediately if there are fewer than max messages to start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {
-    let payload = ExType { a: 2 };
+    let payload = ExType { a: '2' };
     let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload).await.unwrap();
@@ -219,8 +207,8 @@ async fn test_send_recv_all_partial() {
 /// Consumer should yield items immediately if there's a full batch ready on the first poll.
 #[tokio::test]
 async fn test_send_recv_all_full() {
-    let payload1 = ExType { a: 1 };
-    let payload2 = ExType { a: 2 };
+    let payload1 = ExType { a: '1' };
+    let payload2 = ExType { a: '2' };
     let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload1).await.unwrap();
@@ -250,9 +238,9 @@ async fn test_send_recv_all_full() {
 /// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
 #[tokio::test]
 async fn test_send_recv_all_full_then_partial() {
-    let payload1 = ExType { a: 1 };
-    let payload2 = ExType { a: 2 };
-    let payload3 = ExType { a: 3 };
+    let payload1 = ExType { a: '1' };
+    let payload2 = ExType { a: '2' };
+    let payload3 = ExType { a: '3' };
     let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload1).await.unwrap();

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -58,37 +58,24 @@ async fn make_test_queue() -> (QueueBuilder<RedisClusterBackend>, RedisStreamDro
 #[tokio::test]
 async fn test_raw_send_recv() {
     let (builder, _drop) = make_test_queue().await;
-    let payload = b"{\"test\": \"data\"}";
+    let payload = "{\"test\": \"data\"}";
     let (p, mut c) = builder.build_pair().await.unwrap();
 
-    p.send_raw(&payload.to_vec()).await.unwrap();
+    p.send_raw(payload).await.unwrap();
 
     let d = c.receive().await.unwrap();
     assert_eq!(d.borrow_payload().unwrap(), payload);
-}
-
-#[tokio::test]
-async fn test_bytes_send_recv() {
-    let (builder, _drop) = make_test_queue().await;
-    let payload = b"hello";
-    let (p, mut c) = builder.build_pair().await.unwrap();
-
-    p.send_bytes(payload).await.unwrap();
-
-    let d = c.receive().await.unwrap();
-    assert_eq!(d.borrow_payload().unwrap(), payload);
-    d.ack().await.unwrap();
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct ExType {
-    a: u8,
+    a: char,
 }
 
 #[tokio::test]
 async fn test_serde_send_recv() {
     let (builder, _drop) = make_test_queue().await;
-    let payload = ExType { a: 2 };
+    let payload = ExType { a: '2' };
     let (p, mut c) = builder.build_pair().await.unwrap();
 
     p.send_serde_json(&payload).await.unwrap();
@@ -101,12 +88,12 @@ async fn test_serde_send_recv() {
 #[tokio::test]
 async fn test_custom_send_recv() {
     let (builder, _drop) = make_test_queue().await;
-    let payload = ExType { a: 3 };
+    let payload = ExType { a: '3' };
 
-    let encoder = |p: &ExType| Ok(vec![p.a]);
-    let decoder = |p: &Vec<u8>| {
+    let encoder = |p: &ExType| Ok([p.a].into_iter().collect());
+    let decoder = |p: &str| {
         Ok(ExType {
-            a: *p.first().unwrap_or(&0),
+            a: p.chars().next().unwrap_or('\0'),
         })
     };
 
@@ -132,7 +119,7 @@ async fn test_custom_send_recv() {
 async fn test_send_recv_all_partial() {
     let (builder, _drop) = make_test_queue().await;
 
-    let payload = ExType { a: 2 };
+    let payload = ExType { a: '2' };
     let (p, mut c) = builder.build_pair().await.unwrap();
 
     p.send_serde_json(&payload).await.unwrap();
@@ -150,8 +137,8 @@ async fn test_send_recv_all_partial() {
 /// Consumer should yield items immediately if there's a full batch ready on the first poll.
 #[tokio::test]
 async fn test_send_recv_all_full() {
-    let payload1 = ExType { a: 1 };
-    let payload2 = ExType { a: 2 };
+    let payload1 = ExType { a: '1' };
+    let payload2 = ExType { a: '2' };
 
     let (builder, _drop) = make_test_queue().await;
 
@@ -184,9 +171,9 @@ async fn test_send_recv_all_full() {
 /// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
 #[tokio::test]
 async fn test_send_recv_all_full_then_partial() {
-    let payload1 = ExType { a: 1 };
-    let payload2 = ExType { a: 2 };
-    let payload3 = ExType { a: 3 };
+    let payload1 = ExType { a: '1' };
+    let payload2 = ExType { a: '2' };
+    let payload3 = ExType { a: '3' };
 
     let (builder, _drop) = make_test_queue().await;
 
@@ -248,7 +235,7 @@ async fn test_send_recv_all_late_arriving_items() {
 
 #[tokio::test]
 async fn test_scheduled() {
-    let payload1 = ExType { a: 1 };
+    let payload1 = ExType { a: '1' };
 
     let (builder, _drop) = make_test_queue().await;
     let (p, mut c) = builder.build_pair().await.unwrap();
@@ -270,8 +257,8 @@ async fn test_scheduled() {
 
 #[tokio::test]
 async fn test_pending() {
-    let payload1 = ExType { a: 1 };
-    let payload2 = ExType { a: 2 };
+    let payload1 = ExType { a: '1' };
+    let payload2 = ExType { a: '2' };
     let (builder, _drop) = make_test_queue().await;
 
     let (p, mut c) = builder.build_pair().await.unwrap();


### PR DESCRIPTION
In addition to the large API changes, this is a runtime breaking change for every backend except SQS, because everything else was previously supporting non-utf8 content.

This allows the redis delayed queue to encode payload in a key much more efficiently.