### PR TITLE
Remove custom encoders / decoders

### DIFF
--- a/omniqueue/src/builder.rs
+++ b/omniqueue/src/builder.rs
@@ -1,8 +1,6 @@
-use std::{any::TypeId, collections::HashMap, marker::PhantomData, sync::Arc};
+use std::marker::PhantomData;
 
 use crate::{
-    decoding::{CustomDecoder, IntoCustomDecoder},
-    encoding::{CustomEncoder, IntoCustomEncoder},
     DynConsumer, DynProducer, QueueBackend, QueueConsumer as _, QueueProducer as _, Result,
 };
 
@@ -21,12 +19,6 @@ pub struct Dynamic;
 pub struct QueueBuilder<Q: QueueBackend, S = Static> {
     config: Q::Config,
 
-    encoders: HashMap<TypeId, Box<dyn CustomEncoder<Q::PayloadIn>>>,
-    decoders: HashMap<TypeId, Arc<dyn CustomDecoder<Q::PayloadOut>>>,
-
-    encoders_bytes: HashMap<TypeId, Box<dyn CustomEncoder<Vec<u8>>>>,
-    decoders_bytes: HashMap<TypeId, Arc<dyn CustomDecoder<Vec<u8>>>>,
-
     _pd: PhantomData<S>,
 }
 
@@ -39,94 +31,45 @@ impl<Q: QueueBackend> QueueBuilder<Q> {
     pub fn new(config: Q::Config) -> Self {
         Self {
             config,
-            encoders: HashMap::new(),
-            decoders: HashMap::new(),
-            encoders_bytes: HashMap::new(),
-            decoders_bytes: HashMap::new(),
             _pd: PhantomData,
         }
     }
 
-    pub fn with_encoder<I: 'static>(mut self, e: impl IntoCustomEncoder<I, Q::PayloadIn>) -> Self {
-        let encoder = e.into();
-        self.encoders.insert(TypeId::of::<I>(), encoder);
-
-        self
-    }
-
-    pub fn with_decoder<O: 'static>(mut self, d: impl IntoCustomDecoder<Q::PayloadOut, O>) -> Self {
-        let decoder = d.into();
-        self.decoders.insert(TypeId::of::<O>(), decoder);
-
-        self
-    }
-
     pub async fn build_pair(self) -> Result<(Q::Producer, Q::Consumer)> {
-        Q::new_pair(
-            self.config,
-            Arc::new(self.encoders),
-            Arc::new(self.decoders),
-        )
-        .await
+        Q::new_pair(self.config).await
     }
 
     pub async fn build_producer(self) -> Result<Q::Producer> {
-        Q::producing_half(self.config, Arc::new(self.encoders)).await
+        Q::producing_half(self.config).await
     }
 
     pub async fn build_consumer(self) -> Result<Q::Consumer> {
-        Q::consuming_half(self.config, Arc::new(self.decoders)).await
+        Q::consuming_half(self.config).await
     }
 
     pub fn make_dynamic(self) -> QueueBuilder<Q, Dynamic> {
         QueueBuilder {
             config: self.config,
-            encoders: self.encoders,
-            decoders: self.decoders,
-            encoders_bytes: self.encoders_bytes,
-            decoders_bytes: self.decoders_bytes,
             _pd: PhantomData,
         }
     }
 }
 
 impl<Q: QueueBackend + 'static> QueueBuilder<Q, Dynamic> {
-    pub fn with_bytes_encoder<I: 'static>(mut self, e: impl IntoCustomEncoder<I, Vec<u8>>) -> Self {
-        let encoder = e.into();
-        self.encoders_bytes.insert(TypeId::of::<I>(), encoder);
-
-        self
-    }
-
-    pub fn with_bytes_decoder<O: 'static>(mut self, d: impl IntoCustomDecoder<Vec<u8>, O>) -> Self {
-        let decoder = d.into();
-        self.decoders_bytes.insert(TypeId::of::<O>(), decoder);
-
-        self
-    }
-
     pub async fn build_pair(self) -> Result<(DynProducer, DynConsumer)> {
-        let (p, c) = Q::new_pair(
-            self.config,
-            Arc::new(self.encoders),
-            Arc::new(self.decoders),
-        )
-        .await?;
-        Ok((
-            p.into_dyn(Arc::new(self.encoders_bytes)),
-            c.into_dyn(Arc::new(self.decoders_bytes)),
-        ))
+        let (p, c) = Q::new_pair(self.config).await?;
+        Ok((p.into_dyn(), c.into_dyn()))
     }
 
     pub async fn build_producer(self) -> Result<DynProducer> {
-        let p = Q::producing_half(self.config, Arc::new(self.encoders)).await?;
+        let p = Q::producing_half(self.config).await?;
 
-        Ok(p.into_dyn(Arc::new(self.encoders_bytes)))
+        Ok(p.into_dyn())
     }
 
     pub async fn build_consumer(self) -> Result<DynConsumer> {
-        let c = Q::consuming_half(self.config, Arc::new(self.decoders)).await?;
+        let c = Q::consuming_half(self.config).await?;
 
-        Ok(c.into_dyn(Arc::new(self.decoders_bytes)))
+        Ok(c.into_dyn())
     }
 }

--- a/omniqueue/tests/it/gcp_pubsub.rs
+++ b/omniqueue/tests/it/gcp_pubsub.rs
@@ -169,35 +169,6 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-#[tokio::test]
-async fn test_custom_send_recv() {
-    let payload = ExType { a: 3 };
-
-    let encoder = |p: &ExType| Ok(vec![p.a]);
-    let decoder = |p: &Vec<u8>| {
-        Ok(ExType {
-            a: p.first().copied().unwrap_or(0),
-        })
-    };
-
-    let (p, mut c) = make_test_queue()
-        .await
-        .with_encoder(encoder)
-        .with_decoder(decoder)
-        .build_pair()
-        .await
-        .unwrap();
-
-    p.send_custom(&payload).await.unwrap();
-
-    let d = c.receive().await.unwrap();
-    assert_eq!(d.payload_custom::<ExType>().unwrap().unwrap(), payload);
-
-    // Because it doesn't use JSON, this should fail:
-    d.payload_serde_json::<ExType>().unwrap_err();
-    d.ack().await.unwrap();
-}
-
 /// Consumer will return immediately if there are fewer than max messages to start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {

--- a/omniqueue/tests/it/rabbitmq.rs
+++ b/omniqueue/tests/it/rabbitmq.rs
@@ -142,35 +142,6 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-#[tokio::test]
-async fn test_custom_send_recv() {
-    let payload = ExType { a: 3 };
-
-    let encoder = |p: &ExType| Ok(vec![p.a]);
-    let decoder = |p: &Vec<u8>| {
-        Ok(ExType {
-            a: *p.first().unwrap_or(&0),
-        })
-    };
-
-    let (p, mut c) = make_test_queue(None, false)
-        .await
-        .with_encoder(encoder)
-        .with_decoder(decoder)
-        .build_pair()
-        .await
-        .unwrap();
-
-    p.send_custom(&payload).await.unwrap();
-
-    let d = c.receive().await.unwrap();
-    assert_eq!(d.payload_custom::<ExType>().unwrap().unwrap(), payload);
-
-    // Because it doesn't use JSON, this should fail:
-    d.payload_serde_json::<ExType>().unwrap_err();
-    d.ack().await.unwrap();
-}
-
 /// Consumer will return immediately if there are fewer than max messages to start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -95,35 +95,6 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-#[tokio::test]
-async fn test_custom_send_recv() {
-    let (builder, _drop) = make_test_queue().await;
-    let payload = ExType { a: 3 };
-
-    let encoder = |p: &ExType| Ok(vec![p.a]);
-    let decoder = |p: &Vec<u8>| {
-        Ok(ExType {
-            a: *p.first().unwrap_or(&0),
-        })
-    };
-
-    let (p, mut c) = builder
-        .with_encoder(encoder)
-        .with_decoder(decoder)
-        .build_pair()
-        .await
-        .unwrap();
-
-    p.send_custom(&payload).await.unwrap();
-
-    let d = c.receive().await.unwrap();
-    assert_eq!(d.payload_custom::<ExType>().unwrap().unwrap(), payload);
-
-    // Because it doesn't use JSON, this should fail:
-    d.payload_serde_json::<ExType>().unwrap_err();
-    d.ack().await.unwrap();
-}
-
 /// Consumer will return immediately if there are fewer than max messages to start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -98,35 +98,6 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-#[tokio::test]
-async fn test_custom_send_recv() {
-    let (builder, _drop) = make_test_queue().await;
-    let payload = ExType { a: 3 };
-
-    let encoder = |p: &ExType| Ok(vec![p.a]);
-    let decoder = |p: &Vec<u8>| {
-        Ok(ExType {
-            a: *p.first().unwrap_or(&0),
-        })
-    };
-
-    let (p, mut c) = builder
-        .with_encoder(encoder)
-        .with_decoder(decoder)
-        .build_pair()
-        .await
-        .unwrap();
-
-    p.send_custom(&payload).await.unwrap();
-
-    let d = c.receive().await.unwrap();
-    assert_eq!(d.payload_custom::<ExType>().unwrap().unwrap(), payload);
-
-    // Because it doesn't use JSON, this should fail:
-    d.payload_serde_json::<ExType>().unwrap_err();
-    d.ack().await.unwrap();
-}
-
 /// Consumer will return immediately if there are fewer than max messages to start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {

--- a/omniqueue/tests/it/sqs.rs
+++ b/omniqueue/tests/it/sqs.rs
@@ -86,35 +86,6 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-#[tokio::test]
-async fn test_custom_send_recv() {
-    let payload = ExType { a: 3 };
-
-    let encoder = |p: &ExType| Ok(format!("{}", p.a));
-    let decoder = |p: &String| {
-        Ok(ExType {
-            a: p.parse().unwrap_or(0),
-        })
-    };
-
-    let (p, mut c) = make_test_queue()
-        .await
-        .with_encoder(encoder)
-        .with_decoder(decoder)
-        .build_pair()
-        .await
-        .unwrap();
-
-    p.send_custom(&payload).await.unwrap();
-
-    let d = c.receive().await.unwrap();
-    assert_eq!(d.payload_custom::<ExType>().unwrap().unwrap(), payload);
-
-    // Because it doesn't use JSON, this should fail:
-    d.payload_serde_json::<ExType>().unwrap_err();
-    d.ack().await.unwrap();
-}
-
 /// Consumer will return immediately if there are fewer than max messages to start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {


### PR DESCRIPTION
Custom encoding / decoding can be handled at a higher level with less overhead, and custom byte encoders / decoders in particular had no tests at all.