### PR TITLE
Add rabbitmq-with-message-ids feature

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -24,6 +24,7 @@ serde = "1.0.196"
 serde_json = "1"
 svix-ksuid = { version = "0.8.0", optional = true }
 thiserror = "1"
+time = { version = "0.3.34", optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = "0.1"
 
@@ -40,6 +41,8 @@ default = ["in_memory", "gcp_pubsub", "rabbitmq", "redis", "redis_cluster", "sqs
 in_memory = []
 gcp_pubsub = ["dep:futures-util", "dep:google-cloud-googleapis", "dep:google-cloud-pubsub"]
 rabbitmq = ["dep:futures-util", "dep:lapin"]
+# Generate message IDs for queue items. Likely not needed outside of Svix.
+rabbitmq-with-message-ids = ["rabbitmq", "dep:time"]
 redis = ["dep:bb8", "dep:bb8-redis", "dep:redis", "dep:svix-ksuid"]
 redis_cluster = ["redis", "redis/cluster-async"]
 sqs = ["dep:aws-config", "dep:aws-sdk-sqs"]

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -13,6 +13,8 @@ pub use lapin::{
     BasicProperties, Channel, Connection, ConnectionProperties, Consumer,
 };
 use serde::Serialize;
+use svix_ksuid::{KsuidLike as _, KsuidMs};
+use time::OffsetDateTime;
 
 use crate::{
     builder::{QueueBuilder, Static},
@@ -135,6 +137,10 @@ impl RabbitMqProducer {
         headers: Option<FieldTable>,
     ) -> Result<()> {
         let mut properties = self.properties.clone();
+        if cfg!(feature = "rabbitmq-with-message-ids") {
+            let id = &KsuidMs::new(Some(OffsetDateTime::now_utc()), None);
+            properties = properties.with_message_id(id.to_string().into());
+        }
         if let Some(headers) = headers {
             properties = properties.with_headers(headers);
         }

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -129,19 +129,32 @@ pub struct RabbitMqProducer {
 }
 
 impl RabbitMqProducer {
-    pub async fn send_raw(&self, payload: &[u8]) -> Result<()> {
+    async fn send_raw_with_headers(
+        &self,
+        payload: &[u8],
+        headers: Option<FieldTable>,
+    ) -> Result<()> {
+        let mut properties = self.properties.clone();
+        if let Some(headers) = headers {
+            properties = properties.with_headers(headers);
+        }
+
         self.channel
             .basic_publish(
                 &self.exchange,
                 &self.routing_key,
                 self.options,
                 payload,
-                self.properties.clone(),
+                properties,
             )
             .await
             .map_err(QueueError::generic)?;
 
         Ok(())
+    }
+
+    pub async fn send_raw(&self, payload: &[u8]) -> Result<()> {
+        self.send_raw_with_headers(payload, None).await
     }
 
     pub async fn send_serde_json<P: Serialize + Sync>(&self, payload: &P) -> Result<()> {
@@ -158,18 +171,7 @@ impl RabbitMqProducer {
             .map_err(|_| QueueError::Generic("delay is too large".into()))?;
         headers.insert("x-delay".into(), AMQPValue::LongUInt(delay_ms));
 
-        self.channel
-            .basic_publish(
-                &self.exchange,
-                &self.routing_key,
-                self.options,
-                payload,
-                self.properties.clone().with_headers(headers),
-            )
-            .await
-            .map_err(QueueError::generic)?;
-
-        Ok(())
+        self.send_raw_with_headers(payload, Some(headers)).await
     }
 
     pub async fn send_serde_json_scheduled<P: Serialize + Sync>(


### PR DESCRIPTION
To allow `svix-server` to restore compatibility with old versions of `svix-server` workers.