### PR TITLE
Use nightly rustfmt to control comment wrapping and import formatting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,19 @@ on:
   pull_request:
 
 jobs:
+  check-fmt:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: rustfmt
+        run: cargo fmt -- --check
+
   test-versions:
     name: Library Lint
     runs-on: ubuntu-latest
@@ -22,15 +35,12 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
-        components: clippy, rustfmt
+        components: clippy
 
     - uses: Swatinem/rust-cache@v1
 
     - name: Clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
-
-    - name: rustfmt
-      run: cargo fmt -- --check
 
     - name: Start test dependencies
       run: docker-compose -f "./testing-docker-compose.yml" up -d

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,3 @@
+wrap_comments = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/omniqueue/src/backends/in_memory.rs
+++ b/omniqueue/src/backends/in_memory.rs
@@ -126,8 +126,9 @@ impl InMemoryConsumer {
         }
 
         if max_messages > 1 {
-            // `try_recv` will break the loop if no ready items are already buffered in the channel.
-            // This should allow us to opportunistically fill up the buffer in the remaining time.
+            // `try_recv` will break the loop if no ready items are already
+            // buffered in the channel. This should allow us to
+            // opportunistically fill up the buffer in the remaining time.
             while let Ok(x) = self.rx.try_recv() {
                 out.push(self.wrap_payload(x));
                 if out.len() >= max_messages || start.elapsed() >= deadline {
@@ -176,8 +177,9 @@ impl Acker for InMemoryAcker {
 
 #[cfg(test)]
 mod tests {
-    use serde::{Deserialize, Serialize};
     use std::time::{Duration, Instant};
+
+    use serde::{Deserialize, Serialize};
 
     use super::InMemoryBackend;
     use crate::{QueueBuilder, QueueProducer};
@@ -220,7 +222,8 @@ mod tests {
         a: u8,
     }
 
-    /// Consumer will return immediately if there are fewer than max messages to start with.
+    /// Consumer will return immediately if there are fewer than max messages to
+    /// start with.
     #[tokio::test]
     async fn test_send_recv_all_partial() {
         let payload = ExType { a: 2 };
@@ -242,7 +245,8 @@ mod tests {
         assert!(now.elapsed() <= deadline);
     }
 
-    /// Consumer should yield items immediately if there's a full batch ready on the first poll.
+    /// Consumer should yield items immediately if there's a full batch ready on
+    /// the first poll.
     #[tokio::test]
     async fn test_send_recv_all_full() {
         let payload1 = ExType { a: 1 };
@@ -273,11 +277,13 @@ mod tests {
             payload2
         );
         d2.ack().await.unwrap();
-        // N.b. it's still possible this could turn up false if the test runs too slow.
+        // N.b. it's still possible this could turn up false if the test runs
+        // too slow.
         assert!(now.elapsed() < deadline);
     }
 
-    /// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+    /// Consumer will return the full batch immediately, but also return
+    /// immediately if a partial batch is ready.
     #[tokio::test]
     async fn test_send_recv_all_full_then_partial() {
         let payload1 = ExType { a: 1 };

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -233,8 +233,9 @@ impl RabbitMqConsumer {
         }
 
         if max_messages > 1 {
-            // `now_or_never` will break the loop if no ready items are already buffered in the stream.
-            // This should allow us to opportunistically fill up the buffer in the remaining time.
+            // `now_or_never` will break the loop if no ready items are already
+            // buffered in the stream. This should allow us to opportunistically
+            // fill up the buffer in the remaining time.
             while let Some(Some(x)) = stream.next().now_or_never() {
                 out.push(x?);
                 if out.len() >= max_messages || start.elapsed() >= deadline {

--- a/omniqueue/src/backends/redis/cluster.rs
+++ b/omniqueue/src/backends/redis/cluster.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
-
 use redis::{
     cluster::{ClusterClient, ClusterClientBuilder},
     ErrorKind, IntoConnectionInfo, RedisError,
 };
 
-/// ConnectionManager that implements `bb8::ManageConnection` and supports asynchronous clustered
-/// connections via `redis::cluster::ClusterClient`
+/// ConnectionManager that implements `bb8::ManageConnection` and supports
+/// asynchronous clustered connections via `redis::cluster::ClusterClient`
 #[derive(Clone)]
 pub struct RedisClusterConnectionManager {
     client: ClusterClient,

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -1,9 +1,10 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use aws_sdk_sqs::types::Message;
 use aws_sdk_sqs::{
-    operation::delete_message::DeleteMessageError, types::error::ReceiptHandleIsInvalid, Client,
+    operation::delete_message::DeleteMessageError,
+    types::{error::ReceiptHandleIsInvalid, Message},
+    Client,
 };
 use serde::Serialize;
 

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -1,16 +1,16 @@
 //! # Omniqueue
 //!
-//! Omniqueue provides a high-level interface for sending and receiving the following over a range
-//! of queue backends:
+//! Omniqueue provides a high-level interface for sending and receiving the
+//! following over a range of queue backends:
 //!
 //!   * Raw byte arrays in the way most compatible with the queue backend
-//!   * JSON encoded byte arrays for types that implement [`serde::Deserialize`] and
-//!     [`serde::Serialize`]
+//!   * JSON encoded byte arrays for types that implement [`serde::Deserialize`]
+//!     and [`serde::Serialize`]
 //!
 //! ## Cargo Features
 //!
-//! Each backend is enabled with its associated cargo feature. All backends are enabled by default.
-//! As of present it supports:
+//! Each backend is enabled with its associated cargo feature. All backends are
+//! enabled by default. As of present it supports:
 //!
 //! * In-memory queue
 //! * Google Cloud Pub/Sub
@@ -20,8 +20,8 @@
 //!
 //! ## How to Use Omniqueue
 //!
-//! Each queue backend has a unique configuration type. One of these configurations is taken
-//! when constructing the [`QueueBuilder`].
+//! Each queue backend has a unique configuration type. One of these
+//! configurations is taken when constructing the [`QueueBuilder`].
 //!
 //! To create a simple producer and/or consumer:
 //!
@@ -64,10 +64,11 @@
 //!
 //! ## `DynProducer`s and `DynConsumer`s
 //!
-//! Dynamic-dispatch can be used easily for when you're not sure which backend to use at
-//! compile-time.
+//! Dynamic-dispatch can be used easily for when you're not sure which backend
+//! to use at compile-time.
 //!
-//! Making a `DynProducer` or `DynConsumer` is as simple as adding one line to the builder:
+//! Making a `DynProducer` or `DynConsumer` is as simple as adding one line to
+//! the builder:
 //!
 //! ```no_run
 //! # async {

--- a/omniqueue/src/queue/consumer.rs
+++ b/omniqueue/src/queue/consumer.rs
@@ -1,8 +1,7 @@
 use std::{future::Future, pin::Pin, time::Duration};
 
-use crate::{QueuePayload, Result};
-
 use super::Delivery;
+use crate::{QueuePayload, Result};
 
 pub trait QueueConsumer: Send + Sized {
     type Payload: QueuePayload;

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -14,9 +14,11 @@ pub use self::{
     producer::{DynProducer, QueueProducer},
 };
 
-/// A marker trait with utility functions meant for the creation of new producers and/or consumers.
+/// A marker trait with utility functions meant for the creation of new
+/// producers and/or consumers.
 ///
-/// This trait is meant to be implemented on an empty struct representing the backend as a whole.
+/// This trait is meant to be implemented on an empty struct representing the
+/// backend as a whole.
 pub trait QueueBackend {
     type PayloadIn: QueuePayload;
     type PayloadOut: QueuePayload;
@@ -45,23 +47,26 @@ impl Delivery {
     ///
     /// On failure, `self` is returned alongside the error to allow retrying.
     ///
-    /// The exact nature of this will vary per backend, but usually it ensures that the same message
-    /// is not reprocessed.
+    /// The exact nature of this will vary per backend, but usually it ensures
+    /// that the same message is not reprocessed.
     pub async fn ack(mut self) -> Result<(), (QueueError, Self)> {
         self.acker.ack().await.map_err(|e| (e, self))
     }
 
-    /// Explicitly does not Acknowledge the successful processing of this [`Delivery`].
+    /// Explicitly does not Acknowledge the successful processing of this
+    /// [`Delivery`].
     ///
     /// On failure, `self` is returned alongside the error to allow retrying.
     ///
-    /// The exact nature of this will vary by backend, but usually it ensures that the same message
-    /// is either reinserted into the same queue or is sent to a separate collection.
+    /// The exact nature of this will vary by backend, but usually it ensures
+    /// that the same message is either reinserted into the same queue or is
+    /// sent to a separate collection.
     pub async fn nack(mut self) -> Result<(), (QueueError, Self)> {
         self.acker.nack().await.map_err(|e| (e, self))
     }
 
-    /// This method will take the contained bytes out of the delivery, doing no further processing.
+    /// This method will take the contained bytes out of the delivery, doing no
+    /// further processing.
     ///
     /// Once called, subsequent calls to any payload methods will fail.
     pub fn take_payload(&mut self) -> Option<Vec<u8>> {

--- a/omniqueue/tests/it/rabbitmq.rs
+++ b/omniqueue/tests/it/rabbitmq.rs
@@ -1,8 +1,10 @@
-use lapin::options::ExchangeDeclareOptions;
-use lapin::types::AMQPValue;
+use std::time::{Duration, Instant};
+
 use lapin::{
-    options::{BasicConsumeOptions, BasicPublishOptions, QueueDeclareOptions},
-    types::FieldTable,
+    options::{
+        BasicConsumeOptions, BasicPublishOptions, ExchangeDeclareOptions, QueueDeclareOptions,
+    },
+    types::{AMQPValue, FieldTable},
     BasicProperties, Connection, ConnectionProperties, ExchangeKind,
 };
 use omniqueue::{
@@ -10,15 +12,15 @@ use omniqueue::{
     QueueBuilder,
 };
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
 
 const MQ_URI: &str = "amqp://guest:guest@localhost:5672/%2f";
 
-/// Returns a [`QueueBuilder`] configured to connect to the RabbitMQ instance spawned by the file
-/// `testing-docker-compose.yaml` in the root of the repository.
+/// Returns a [`QueueBuilder`] configured to connect to the RabbitMQ instance
+/// spawned by the file `testing-docker-compose.yaml` in the root of the
+/// repository.
 ///
-/// Additionally this will make a temporary queue on that instance for the duration of the test such
-/// as to ensure there is no stealing.w
+/// Additionally this will make a temporary queue on that instance for the
+/// duration of the test such as to ensure there is no stealing.w
 async fn make_test_queue(
     prefetch_count: Option<u16>,
     reinsert_on_nack: bool,
@@ -144,7 +146,8 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-/// Consumer will return immediately if there are fewer than max messages to start with.
+/// Consumer will return immediately if there are fewer than max messages to
+/// start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {
     let payload = ExType { a: 2 };
@@ -166,7 +169,8 @@ async fn test_send_recv_all_partial() {
     assert!(now.elapsed() <= deadline);
 }
 
-/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+/// Consumer should yield items immediately if there's a full batch ready on the
+/// first poll.
 #[tokio::test]
 async fn test_send_recv_all_full() {
     let payload1 = ExType { a: 1 };
@@ -180,8 +184,9 @@ async fn test_send_recv_all_full() {
     p.send_serde_json(&payload1).await.unwrap();
     p.send_serde_json(&payload2).await.unwrap();
 
-    // XXX: rabbit's receive_all impl relies on stream items to be in a ready state in order for
-    // them to be batched together. Sleeping to help them settle before we poll.
+    // XXX: rabbit's receive_all impl relies on stream items to be in a ready
+    // state in order for them to be batched together. Sleeping to help them
+    // settle before we poll.
     tokio::time::sleep(Duration::from_millis(100)).await;
     let deadline = Duration::from_secs(1);
 
@@ -201,11 +206,13 @@ async fn test_send_recv_all_full() {
         payload2
     );
     d2.ack().await.unwrap();
-    // N.b. it's still possible this could turn up false if the test runs too slow.
+    // N.b. it's still possible this could turn up false if the test runs too
+    // slow.
     assert!(now.elapsed() < deadline);
 }
 
-/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+/// Consumer will return the full batch immediately, but also return immediately
+/// if a partial batch is ready.
 #[tokio::test]
 async fn test_send_recv_all_full_then_partial() {
     let payload1 = ExType { a: 1 };
@@ -221,8 +228,9 @@ async fn test_send_recv_all_full_then_partial() {
     p.send_serde_json(&payload2).await.unwrap();
     p.send_serde_json(&payload3).await.unwrap();
 
-    // XXX: rabbit's receive_all impl relies on stream items to be in a ready state in order for
-    // them to be batched together. Sleeping to help them settle before we poll.
+    // XXX: rabbit's receive_all impl relies on stream items to be in a ready
+    // state in order for them to be batched together. Sleeping to help them
+    // settle before we poll.
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let deadline = Duration::from_secs(1);

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -1,10 +1,11 @@
+use std::time::{Duration, Instant};
+
 use omniqueue::{
     backends::{RedisBackend, RedisConfig},
     QueueBuilder,
 };
 use redis::{AsyncCommands, Client, Commands};
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
 
 const ROOT_URL: &str = "redis://localhost";
 
@@ -17,13 +18,15 @@ impl Drop for RedisStreamDrop {
     }
 }
 
-/// Returns a [`QueueBuilder`] configured to connect to the Redis instance spawned by the file
-/// `testing-docker-compose.yaml` in the root of the repository.
+/// Returns a [`QueueBuilder`] configured to connect to the Redis instance
+/// spawned by the file `testing-docker-compose.yaml` in the root of the
+/// repository.
 ///
-/// Additionally this will make a temporary stream on that instance for the duration of the test
-/// such as to ensure there is no stealing
+/// Additionally this will make a temporary stream on that instance for the
+/// duration of the test such as to ensure there is no stealing
 ///
-/// This will also return a [`RedisStreamDrop`] to clean up the stream after the test ends.
+/// This will also return a [`RedisStreamDrop`] to clean up the stream after the
+/// test ends.
 async fn make_test_queue() -> (QueueBuilder<RedisBackend>, RedisStreamDrop) {
     let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
         .take(8)
@@ -98,7 +101,8 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-/// Consumer will return immediately if there are fewer than max messages to start with.
+/// Consumer will return immediately if there are fewer than max messages to
+/// start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {
     let (builder, _drop) = make_test_queue().await;
@@ -118,7 +122,8 @@ async fn test_send_recv_all_partial() {
     assert!(now.elapsed() <= deadline);
 }
 
-/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+/// Consumer should yield items immediately if there's a full batch ready on the
+/// first poll.
 #[tokio::test]
 async fn test_send_recv_all_full() {
     let payload1 = ExType { a: 1 };
@@ -148,11 +153,13 @@ async fn test_send_recv_all_full() {
         payload2
     );
     d2.ack().await.unwrap();
-    // N.b. it's still possible this could turn up false if the test runs too slow.
+    // N.b. it's still possible this could turn up false if the test runs too
+    // slow.
     assert!(now.elapsed() < deadline);
 }
 
-/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+/// Consumer will return the full batch immediately, but also return immediately
+/// if a partial batch is ready.
 #[tokio::test]
 async fn test_send_recv_all_full_then_partial() {
     let payload1 = ExType { a: 1 };
@@ -252,7 +259,8 @@ async fn test_pending() {
     let delivery1 = c.receive().await.unwrap();
     let delivery2 = c.receive().await.unwrap();
 
-    // All items claimed, but not yet ack'd. There shouldn't be anything available yet.
+    // All items claimed, but not yet ack'd. There shouldn't be anything available
+    // yet.
     assert!(c
         .receive_all(1, Duration::from_millis(1))
         .await

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -1,10 +1,11 @@
+use std::time::{Duration, Instant};
+
 use omniqueue::{
     backends::{RedisClusterBackend, RedisConfig},
     QueueBuilder,
 };
 use redis::{cluster::ClusterClient, AsyncCommands, Commands};
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
 
 const ROOT_URL: &str = "redis://localhost:6380";
 
@@ -17,13 +18,15 @@ impl Drop for RedisStreamDrop {
     }
 }
 
-/// Returns a [`QueueBuilder`] configured to connect to the Redis instance spawned by the file
-/// `testing-docker-compose.yaml` in the root of the repository.
+/// Returns a [`QueueBuilder`] configured to connect to the Redis instance
+/// spawned by the file `testing-docker-compose.yaml` in the root of the
+/// repository.
 ///
-/// Additionally this will make a temporary stream on that instance for the duration of the test
-/// such as to ensure there is no stealing
+/// Additionally this will make a temporary stream on that instance for the
+/// duration of the test such as to ensure there is no stealing
 ///
-/// This will also return a [`RedisStreamDrop`] to clean up the stream after the test ends.
+/// This will also return a [`RedisStreamDrop`] to clean up the stream after the
+/// test ends.
 async fn make_test_queue() -> (QueueBuilder<RedisClusterBackend>, RedisStreamDrop) {
     let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
         .take(8)
@@ -101,7 +104,8 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-/// Consumer will return immediately if there are fewer than max messages to start with.
+/// Consumer will return immediately if there are fewer than max messages to
+/// start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {
     let (builder, _drop) = make_test_queue().await;
@@ -121,7 +125,8 @@ async fn test_send_recv_all_partial() {
     assert!(now.elapsed() <= deadline);
 }
 
-/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+/// Consumer should yield items immediately if there's a full batch ready on the
+/// first poll.
 #[tokio::test]
 async fn test_send_recv_all_full() {
     let payload1 = ExType { a: 1 };
@@ -151,11 +156,13 @@ async fn test_send_recv_all_full() {
         payload2
     );
     d2.ack().await.unwrap();
-    // N.b. it's still possible this could turn up false if the test runs too slow.
+    // N.b. it's still possible this could turn up false if the test runs too
+    // slow.
     assert!(now.elapsed() < deadline);
 }
 
-/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+/// Consumer will return the full batch immediately, but also return immediately
+/// if a partial batch is ready.
 #[tokio::test]
 async fn test_send_recv_all_full_then_partial() {
     let payload1 = ExType { a: 1 };
@@ -255,7 +262,8 @@ async fn test_pending() {
     let delivery1 = c.receive().await.unwrap();
     let delivery2 = c.receive().await.unwrap();
 
-    // All items claimed, but not yet ack'd. There shouldn't be anything available yet.
+    // All items claimed, but not yet ack'd. There shouldn't be anything
+    // available yet.
     assert!(c
         .receive_all(1, Duration::from_millis(1))
         .await

--- a/omniqueue/tests/it/sqs.rs
+++ b/omniqueue/tests/it/sqs.rs
@@ -1,10 +1,11 @@
+use std::time::{Duration, Instant};
+
 use aws_sdk_sqs::Client;
 use omniqueue::{
     backends::{SqsBackend, SqsConfig},
     QueueBuilder,
 };
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
 
 const ROOT_URL: &str = "http://localhost:9324";
 const DEFAULT_CFG: [(&str, &str); 3] = [
@@ -13,11 +14,11 @@ const DEFAULT_CFG: [(&str, &str); 3] = [
     ("AWS_SECRET_ACCESS_KEY", "x"),
 ];
 
-/// Returns a [`QueueBuilder`] configured to connect to the SQS instance spawned by the file
-/// `testing-docker-compose.yaml` in the root of the repository.
+/// Returns a [`QueueBuilder`] configured to connect to the SQS instance spawned
+/// by the file `testing-docker-compose.yaml` in the root of the repository.
 ///
-/// Additionally this will make a temporary queue on that instance for the duration of the test such
-/// as to ensure there is no stealing.w
+/// Additionally this will make a temporary queue on that instance for the
+/// duration of the test such as to ensure there is no stealing.w
 async fn make_test_queue() -> QueueBuilder<SqsBackend> {
     for (var, val) in &DEFAULT_CFG {
         if std::env::var(var).is_err() {
@@ -88,7 +89,8 @@ async fn test_serde_send_recv() {
     d.ack().await.unwrap();
 }
 
-/// Consumer will return immediately if there are fewer than max messages to start with.
+/// Consumer will return immediately if there are fewer than max messages to
+/// start with.
 #[tokio::test]
 async fn test_send_recv_all_partial() {
     let payload = ExType { a: 2 };
@@ -106,7 +108,8 @@ async fn test_send_recv_all_partial() {
     assert!(now.elapsed() <= deadline);
 }
 
-/// Consumer should yield items immediately if there's a full batch ready on the first poll.
+/// Consumer should yield items immediately if there's a full batch ready on the
+/// first poll.
 #[tokio::test]
 async fn test_send_recv_all_full() {
     let payload1 = ExType { a: 1 };
@@ -133,11 +136,13 @@ async fn test_send_recv_all_full() {
         payload2
     );
     d2.ack().await.unwrap();
-    // N.b. it's still possible this could turn up false if the test runs too slow.
+    // N.b. it's still possible this could turn up false if the test runs too
+    // slow.
     assert!(now.elapsed() < deadline);
 }
 
-/// Consumer will return the full batch immediately, but also return immediately if a partial batch is ready.
+/// Consumer will return the full batch immediately, but also return immediately
+/// if a partial batch is ready.
 #[tokio::test]
 async fn test_send_recv_all_full_then_partial() {
     let payload1 = ExType { a: 1 };


### PR DESCRIPTION
## Motivation

This makes some things more uniform (e.g. comment width, import grouping).

## Solution

Use some nightly-only rustfmt configuration options.

This change will result in occasional extra CI complaints, but you can

<details><summary>set up your local development environment to use nightly rustfmt</summary>

### For VSCode

To set up auto-format with nightly rustfmt:

```json
"rust-analyzer.rustfmt.extraArgs": [
    "+nightly"
],
```

To set up formatting on save:

```json
"editor.formatOnSave": true,
```

or just for Rust:

```json
"[rust]": {
    "editor.formatOnSave": true
},
```

### For Sublime Text

See [Owen's comment below](https://github.com/svix/omniqueue-rs/pull/54#issuecomment-1973966099).

</details>

<details><summary>... or fix those CI complaints whenever the come up</summary>

by executing

```sh
cargo +nightly fmt
```

</details>

## Further notes

`wrap_comments` sometimes leaves over-long comment lines even though they can easily be re-wrapped so I fixed up those instances by hand.

Would also be possible to set a wider line length for comments if you prefer.

