### PR TITLE
Deprecate QueueError::Unsupported

### DIFF
--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -121,7 +121,9 @@ pub enum QueueError {
 
     #[error("{0}")]
     Generic(Box<dyn std::error::Error + Send + Sync>),
+
     #[error("{0}")]
+    #[deprecated = "This variant is never created inside omniqueue"]
     Unsupported(&'static str),
 }
 


### PR DESCRIPTION
This variant is never created inside omniqueue.