### PR TITLE
Add QueueError::PayloadTooLarge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Remove `QueueError::Unsupported`
   - This variant was never constructed inside `omniqueue`
 
+## Additions
+
+- Add `QueueError::PayloadTooLarge`
+
 # 0.2.0
 
 This release is a big one, and we are considering omniqueue out of early development now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# unreleased
+
+## Breaking changes
+
+- Remove `QueueError::Unsupported`
+  - This variant was never constructed inside `omniqueue`
+
 # 0.2.0
 
 This release is a big one, and we are considering omniqueue out of early development now.

--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -17,6 +17,7 @@ azure_storage = { version = "0.19.0", optional = true }
 azure_storage_queues = { version = "0.19.0", optional = true }
 bb8 = { version = "0.8", optional = true }
 bb8-redis = { version = "0.14.0", optional = true }
+bytesize = "1.3.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["async-await", "std"], optional = true }
 google-cloud-googleapis = { version = "0.12.0", optional = true }
 google-cloud-pubsub = { version = "0.23.0", optional = true }

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -236,9 +236,10 @@ impl SqsProducer {
 
     pub async fn send_raw_scheduled(&self, payload: &str, delay: Duration) -> Result<()> {
         if payload.len() > MAX_PAYLOAD_SIZE {
-            return Err(QueueError::Generic(
-                "payload exceeds SQS size limit of 256K".into(),
-            ));
+            return Err(QueueError::PayloadTooLarge {
+                limit: MAX_PAYLOAD_SIZE,
+                actual: payload.len(),
+            });
         }
 
         self.client

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -117,15 +117,12 @@ pub enum QueueError {
 
     #[error("no data was received from the queue")]
     NoData,
+
     #[error("(de)serialization error")]
     Serde(#[from] serde_json::Error),
 
     #[error("{0}")]
     Generic(Box<dyn std::error::Error + Send + Sync>),
-
-    #[error("{0}")]
-    #[deprecated = "This variant is never created inside omniqueue"]
-    Unsupported(&'static str),
 }
 
 impl QueueError {

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -87,6 +87,7 @@
 
 use std::fmt::Debug;
 
+use bytesize::ByteSize;
 use thiserror::Error;
 
 #[macro_use]
@@ -120,6 +121,15 @@ pub enum QueueError {
 
     #[error("(de)serialization error")]
     Serde(#[from] serde_json::Error),
+
+    #[error("payload too large: {} > {}", ByteSize(*actual as u64), ByteSize(*limit as u64))]
+    PayloadTooLarge {
+        /// The size of the serialized message, in bytes.
+        actual: usize,
+
+        /// The message size limit of the queue, in bytes.
+        limit: usize,
+    },
 
     #[error("{0}")]
     Generic(Box<dyn std::error::Error + Send + Sync>),


### PR DESCRIPTION
… and remove `QueueError::Unsupported` since the new error variant requires a semver-incompatible release anyways (due to the error enum being exhaustive).