### PR TITLE
Add RedisBackendBuilder

### DIFF
--- a/omniqueue/src/backends/mod.rs
+++ b/omniqueue/src/backends/mod.rs
@@ -19,9 +19,9 @@ pub use gcp_pubsub::{GcpPubSubBackend, GcpPubSubConfig, GcpPubSubConsumer, GcpPu
 pub use in_memory::{InMemoryBackend, InMemoryConsumer, InMemoryProducer};
 #[cfg(feature = "rabbitmq")]
 pub use rabbitmq::{RabbitMqBackend, RabbitMqConfig, RabbitMqConsumer, RabbitMqProducer};
-#[cfg(feature = "redis_cluster")]
-pub use redis::RedisClusterBackend;
 #[cfg(feature = "redis")]
-pub use redis::{RedisBackend, RedisConfig, RedisConsumer, RedisProducer};
+pub use redis::{RedisBackend, RedisBackendBuilder, RedisConfig, RedisConsumer, RedisProducer};
+#[cfg(feature = "redis_cluster")]
+pub use redis::{RedisClusterBackend, RedisClusterBackendBuilder};
 #[cfg(feature = "sqs")]
 pub use sqs::{SqsBackend, SqsConfig, SqsConsumer, SqsProducer};

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -1,9 +1,6 @@
 use std::time::{Duration, Instant};
 
-use omniqueue::{
-    backends::{RedisBackend, RedisConfig},
-    QueueBuilder,
-};
+use omniqueue::backends::{redis::RedisBackendBuilder, RedisBackend, RedisConfig};
 use redis::{AsyncCommands, Client, Commands};
 use serde::{Deserialize, Serialize};
 
@@ -27,7 +24,7 @@ impl Drop for RedisStreamDrop {
 ///
 /// This will also return a [`RedisStreamDrop`] to clean up the stream after the
 /// test ends.
-async fn make_test_queue() -> (QueueBuilder<RedisBackend>, RedisStreamDrop) {
+async fn make_test_queue() -> (RedisBackendBuilder, RedisStreamDrop) {
     let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
         .take(8)
         .collect();

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -1,9 +1,6 @@
 use std::time::{Duration, Instant};
 
-use omniqueue::{
-    backends::{RedisClusterBackend, RedisConfig},
-    QueueBuilder,
-};
+use omniqueue::backends::{RedisBackend, RedisClusterBackendBuilder, RedisConfig};
 use redis::{cluster::ClusterClient, AsyncCommands, Commands};
 use serde::{Deserialize, Serialize};
 
@@ -27,7 +24,7 @@ impl Drop for RedisStreamDrop {
 ///
 /// This will also return a [`RedisStreamDrop`] to clean up the stream after the
 /// test ends.
-async fn make_test_queue() -> (QueueBuilder<RedisClusterBackend>, RedisStreamDrop) {
+async fn make_test_queue() -> (RedisClusterBackendBuilder, RedisStreamDrop) {
     let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
         .take(8)
         .collect();
@@ -54,7 +51,7 @@ async fn make_test_queue() -> (QueueBuilder<RedisClusterBackend>, RedisStreamDro
     };
 
     (
-        RedisClusterBackend::builder(config),
+        RedisBackend::builder(config).cluster(),
         RedisStreamDrop(stream_name),
     )
 }


### PR DESCRIPTION
… to replace `QueueBuilder<RedisBackend<R>>`.

If we do this for all backends, we'll be able to remove the `QueueBackend` trait and `QueueBuilder` type.