### PR TITLE
Upgrade redis-rs/bb8 again

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -16,13 +16,13 @@ aws-sdk-sqs = { version = "1.13.0", optional = true }
 azure_storage = { version = "0.19.0", optional = true }
 azure_storage_queues = { version = "0.19.0", optional = true }
 bb8 = { version = "0.8", optional = true }
-bb8-redis = { version = "0.14.0", optional = true }
+bb8-redis = { version = "0.15.0", optional = true }
 bytesize = "1.3.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["async-await", "std"], optional = true }
 google-cloud-googleapis = { version = "0.12.0", optional = true }
 google-cloud-pubsub = { version = "0.23.0", optional = true }
 lapin = { version = "2", optional = true }
-redis = { version = "0.24.0", features = ["tokio-comp", "tokio-native-tls-comp", "streams"], optional = true }
+redis = { version = "0.25.3", features = ["tokio-comp", "tokio-native-tls-comp", "streams"], optional = true }
 serde = "1.0.196"
 serde_json = "1"
 svix-ksuid = { version = "0.8.0", optional = true }

--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -37,7 +37,7 @@ use std::{
 
 use async_trait::async_trait;
 use bb8::ManageConnection;
-pub use bb8_redis::RedisMultiplexedConnectionManager;
+pub use bb8_redis::RedisConnectionManager;
 use redis::{
     streams::{StreamClaimReply, StreamId, StreamReadOptions, StreamReadReply},
     AsyncCommands, ExistenceCheck, FromRedisValue, RedisResult, SetExpiry, SetOptions,
@@ -70,7 +70,7 @@ pub trait RedisConnection:
     fn from_dsn(dsn: &str) -> Result<Self>;
 }
 
-impl RedisConnection for RedisMultiplexedConnectionManager {
+impl RedisConnection for RedisConnectionManager {
     type Connection = <Self as ManageConnection>::Connection;
     type Error = <Self as ManageConnection>::Error;
 
@@ -102,7 +102,7 @@ pub struct RedisConfig {
     pub ack_deadline_ms: i64,
 }
 
-pub struct RedisBackend<R = RedisMultiplexedConnectionManager>(PhantomData<R>);
+pub struct RedisBackend<R = RedisConnectionManager>(PhantomData<R>);
 
 #[cfg(feature = "redis_cluster")]
 pub type RedisClusterBackend = RedisBackend<RedisClusterConnectionManager>;
@@ -145,7 +145,7 @@ impl<R: RedisConnection> QueueBackend for RedisBackend<R> {
     }
 }
 
-pub struct RedisBackendBuilder<R = RedisMultiplexedConnectionManager, S = Static> {
+pub struct RedisBackendBuilder<R = RedisConnectionManager, S = Static> {
     config: RedisConfig,
     _phantom: PhantomData<fn() -> (R, S)>,
 }

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -30,7 +30,7 @@ async fn make_test_queue() -> (RedisBackendBuilder, RedisStreamDrop) {
         .collect();
 
     let client = Client::open(ROOT_URL).unwrap();
-    let mut conn = client.get_async_connection().await.unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
 
     let _: () = conn
         .xgroup_create_mkstream(&stream_name, "test_cg", 0i8)


### PR DESCRIPTION
With the reconfigured clustered redis healthcheck,
I believe we're safe to upgrade redis again.

Note: This version of redis-rs imposes a default 1-second
timeout on establishing connections to cluster nodes. I don't
see any reason at the moment to change this, but we may need
to consider exposing this as a configurable parameter in the future.
