### PR TITLE
Remove unnecessary `&mut self` in SQS implementation

### DIFF
--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -291,7 +291,7 @@ impl SqsConsumer {
         }
     }
 
-    pub async fn receive(&mut self) -> Result<Delivery> {
+    pub async fn receive(&self) -> Result<Delivery> {
         let out = self
             .client
             .receive_message()
@@ -309,7 +309,7 @@ impl SqsConsumer {
     }
 
     pub async fn receive_all(
-        &mut self,
+        &self,
         max_messages: usize,
         deadline: Duration,
     ) -> Result<Vec<Delivery>> {

--- a/omniqueue/src/macros.rs
+++ b/omniqueue/src/macros.rs
@@ -8,7 +8,7 @@ macro_rules! impl_queue_consumer {
             type Payload = $payload;
 
             fn receive(&mut self) -> impl std::future::Future<Output = Result<Delivery>> + Send {
-                self.receive()
+                $ident::receive(self)
             }
 
             fn receive_all(
@@ -16,7 +16,7 @@ macro_rules! impl_queue_consumer {
                 max_messages: usize,
                 deadline: Duration,
             ) -> impl std::future::Future<Output = Result<Vec<Delivery>>> + Send {
-                self.receive_all(max_messages, deadline)
+                $ident::receive_all(self, max_messages, deadline)
             }
         }
     };
@@ -35,14 +35,14 @@ macro_rules! impl_queue_producer {
                 &self,
                 payload: &Self::Payload,
             ) -> impl std::future::Future<Output = Result<()>> + Send {
-                self.send_raw(payload)
+                $ident::send_raw(self, payload)
             }
 
             fn send_serde_json<P: serde::Serialize + Sync>(
                 &self,
                 payload: &P,
             ) -> impl std::future::Future<Output = Result<()>> + Send {
-                self.send_serde_json(payload)
+                $ident::send_serde_json(self, payload)
             }
         }
     };
@@ -60,7 +60,7 @@ macro_rules! impl_scheduled_queue_producer {
                 payload: &Self::Payload,
                 delay: Duration,
             ) -> impl std::future::Future<Output = Result<()>> + Send {
-                self.send_raw_scheduled(payload, delay)
+                $ident::send_raw_scheduled(self, payload, delay)
             }
 
             fn send_serde_json_scheduled<P: serde::Serialize + Sync>(
@@ -68,7 +68,7 @@ macro_rules! impl_scheduled_queue_producer {
                 payload: &P,
                 delay: Duration,
             ) -> impl std::future::Future<Output = Result<()>> + Send {
-                self.send_serde_json_scheduled(payload, delay)
+                $ident::send_serde_json_scheduled(self, payload, delay)
             }
         }
     };

--- a/omniqueue/tests/it/sqs.rs
+++ b/omniqueue/tests/it/sqs.rs
@@ -50,7 +50,7 @@ async fn make_test_queue() -> QueueBuilder<SqsBackend> {
 #[tokio::test]
 async fn test_raw_send_recv() {
     let payload = "{\"test\": \"data\"}";
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_raw(payload).await.unwrap();
 
@@ -63,7 +63,7 @@ async fn test_bytes_send_recv() {
     use omniqueue::QueueProducer as _;
 
     let payload = b"hello";
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_bytes(payload).await.unwrap();
 
@@ -80,7 +80,7 @@ pub struct ExType {
 #[tokio::test]
 async fn test_serde_send_recv() {
     let payload = ExType { a: 2 };
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload).await.unwrap();
 
@@ -94,7 +94,7 @@ async fn test_serde_send_recv() {
 #[tokio::test]
 async fn test_send_recv_all_partial() {
     let payload = ExType { a: 2 };
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload).await.unwrap();
     let deadline = Duration::from_secs(1);
@@ -114,7 +114,7 @@ async fn test_send_recv_all_partial() {
 async fn test_send_recv_all_full() {
     let payload1 = ExType { a: 1 };
     let payload2 = ExType { a: 2 };
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload1).await.unwrap();
     p.send_serde_json(&payload2).await.unwrap();
@@ -148,7 +148,7 @@ async fn test_send_recv_all_full_then_partial() {
     let payload1 = ExType { a: 1 };
     let payload2 = ExType { a: 2 };
     let payload3 = ExType { a: 3 };
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     p.send_serde_json(&payload1).await.unwrap();
     p.send_serde_json(&payload2).await.unwrap();
@@ -189,7 +189,7 @@ async fn test_send_recv_all_full_then_partial() {
 /// Consumer will NOT wait indefinitely for at least one item.
 #[tokio::test]
 async fn test_send_recv_all_late_arriving_items() {
-    let (_p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (_p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     let deadline = Duration::from_secs(1);
     let now = Instant::now();
@@ -205,7 +205,7 @@ async fn test_send_recv_all_late_arriving_items() {
 #[tokio::test]
 async fn test_scheduled() {
     let payload1 = ExType { a: 1 };
-    let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
+    let (p, c) = make_test_queue().await.build_pair().await.unwrap();
 
     let delay = Duration::from_secs(3);
     let now = Instant::now();


### PR DESCRIPTION
While attempting to use the SQS implementation, I ran into papercuts with the consumer because `receive()` methods took self by mutable reference.

These, uhh, don't need to do that. I realize the general Consumer traits takes a mutable reference because _some_ underlying implementations require an immutable ref. But when calling the SQS Consumer methods directly, rather than through the consumer trait, this mutable reference is just annoying.

When I made this change, my linter started complaining about unbounded recursion from the macro definitions for implementing the consumer traits. Changing the macros to use the fully qualified _struct_ syntax (e.g. `Struct::method` instead of `&self.method`) seems to fix this?