### PR TITLE
redis: Use associated type bounds to simplify RedisConnection trait

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -6,7 +6,7 @@ description = "An abstraction layer over various queue backends"
 authors = ["Svix Inc. <oss@svix.com>"]
 repository = "https://github.com/svix/omniqueue-rs/"
 readme = "../README.md"
-rust-version = "1.75"
+rust-version = "1.79"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Rust 1.79.0, which includes this feature, stabilizes today.