### PR TITLE
Fix future incompatibility warnings regarding never type fallback

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
       run: cargo hack --each-feature clippy --all-targets -- -D warnings
 
     - name: Start test dependencies
-      run: docker-compose -f "./testing-docker-compose.yml" up -d
+      run: docker compose -f "./testing-docker-compose.yml" up -d
 
     - name: Run tests
       env:
@@ -55,7 +55,7 @@ jobs:
       run: cargo test --all-features
 
     - name: Stop test dependencies
-      run: docker-compose -f "./testing-docker-compose.yml" down
+      run: docker compose -f "./testing-docker-compose.yml" down
 
   typos:
     name: Check for typos

--- a/omniqueue/src/backends/redis/fallback.rs
+++ b/omniqueue/src/backends/redis/fallback.rs
@@ -96,7 +96,8 @@ impl<R: RedisConnection> Acker for RedisFallbackAcker<R> {
 
         self.already_acked_or_nacked = true;
 
-        self.redis
+        let _: () = self
+            .redis
             .get()
             .await
             .map_err(QueueError::generic)?

--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -550,7 +550,8 @@ impl<R: RedisConnection> RedisProducer<R> {
     pub async fn send_raw_scheduled(&self, payload: &[u8], delay: Duration) -> Result<()> {
         let timestamp = unix_timestamp(SystemTime::now() + delay).map_err(QueueError::generic)?;
 
-        self.redis
+        let _: () = self
+            .redis
             .get()
             .await
             .map_err(QueueError::generic)?


### PR DESCRIPTION
We were getting some warnings because we were calling a redis method with a generic return type without specifying what that generic parameter should be. For some reason that I don't fully understand, this previously lead to the compiler inferring that type to be `()`, but the inference algorithm is going to be tweaked for edition 2024 (and maybe earlier editions too, at a later point).