### PR TITLE
Use native async-fn-in-traits for Acker

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.79"
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { version = "0.1", optional = true }
 aws-config = { version = "1.1.5", features = ["behavior-version-latest"], optional = true }
 aws-sdk-sqs = { version = "1.13.0", optional = true }
 azure_storage = { version = "0.20.0", optional = true }
@@ -47,7 +47,7 @@ rabbitmq = ["dep:futures-util", "dep:lapin"]
 # Generate message IDs for queue items. Likely not needed outside of Svix.
 rabbitmq-with-message-ids = ["rabbitmq", "dep:svix-ksuid"]
 redis = ["dep:bb8", "dep:bb8-redis", "dep:redis", "dep:svix-ksuid"]
-redis_cluster = ["redis", "redis/cluster-async"]
+redis_cluster = ["dep:async-trait", "redis", "redis/cluster-async"]
 sqs = ["dep:aws-config", "dep:aws-sdk-sqs"]
 azure_queue_storage = ["dep:azure_storage", "dep:azure_storage_queues"]
 beta = []

--- a/omniqueue/src/backends/azure_queue_storage.rs
+++ b/omniqueue/src/backends/azure_queue_storage.rs
@@ -180,14 +180,14 @@ impl Acker for AqsAcker {
 
 impl AqsConsumer {
     fn wrap_message(&self, message: &Message) -> Delivery {
-        Delivery {
-            acker: Box::new(AqsAcker {
+        Delivery::new(
+            message.message_text.as_bytes().to_owned(),
+            AqsAcker {
                 client: self.client.clone(),
                 pop_receipt: message.pop_receipt(),
                 already_acked_or_nacked: false,
-            }),
-            payload: Some(message.message_text.as_bytes().to_owned()),
-        }
+            },
+        )
     }
 
     /// Note that blocking receives are not supported by Azure Queue Storage.

--- a/omniqueue/src/backends/azure_queue_storage.rs
+++ b/omniqueue/src/backends/azure_queue_storage.rs
@@ -1,6 +1,5 @@
 use std::{num::NonZeroUsize, time::Duration};
 
-use async_trait::async_trait;
 use azure_storage::StorageCredentials;
 use azure_storage_queues::{
     operations::Message, PopReceipt, QueueClient, QueueServiceClientBuilder,
@@ -152,7 +151,6 @@ struct AqsAcker {
     pop_receipt: PopReceipt,
 }
 
-#[async_trait]
 impl Acker for AqsAcker {
     async fn ack(&mut self) -> Result<()> {
         if self.already_acked_or_nacked {

--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use async_trait::async_trait;
 use futures_util::StreamExt;
 use google_cloud_googleapis::pubsub::v1::PubsubMessage;
 use google_cloud_pubsub::{
@@ -274,7 +273,6 @@ impl std::fmt::Debug for GcpPubSubAcker {
     }
 }
 
-#[async_trait]
 impl Acker for GcpPubSubAcker {
     async fn ack(&mut self) -> Result<()> {
         self.recv_msg.ack().await.map_err(QueueError::generic)

--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -223,13 +223,13 @@ impl GcpPubSubConsumer {
         // returned _outside of the Acker_.
         let payload = recv_msg.message.data.drain(..).collect();
 
-        Delivery {
-            acker: Box::new(GcpPubSubAcker {
+        Delivery::new(
+            payload,
+            GcpPubSubAcker {
                 recv_msg,
                 subscription_id: self.subscription_id.clone(),
-            }),
-            payload: Some(payload),
-        }
+            },
+        )
     }
 }
 

--- a/omniqueue/src/backends/in_memory.rs
+++ b/omniqueue/src/backends/in_memory.rs
@@ -96,14 +96,14 @@ pub struct InMemoryConsumer {
 
 impl InMemoryConsumer {
     fn wrap_payload(&self, payload: Vec<u8>) -> Delivery {
-        Delivery {
-            payload: Some(payload.clone()),
-            acker: Box::new(InMemoryAcker {
+        Delivery::new(
+            payload.clone(),
+            InMemoryAcker {
                 tx: self.tx.clone(),
                 payload_copy: Some(payload),
                 already_acked_or_nacked: false,
-            }),
-        }
+            },
+        )
     }
 
     pub async fn receive(&mut self) -> Result<Delivery> {

--- a/omniqueue/src/backends/in_memory.rs
+++ b/omniqueue/src/backends/in_memory.rs
@@ -1,6 +1,5 @@
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
 use serde::Serialize;
 use tokio::sync::mpsc;
 
@@ -153,7 +152,6 @@ struct InMemoryAcker {
     already_acked_or_nacked: bool,
 }
 
-#[async_trait]
 impl Acker for InMemoryAcker {
     async fn ack(&mut self) -> Result<()> {
         if self.already_acked_or_nacked {

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -1,6 +1,5 @@
 use std::time::{Duration, Instant};
 
-use async_trait::async_trait;
 use futures_util::{FutureExt, StreamExt};
 use lapin::types::AMQPValue;
 pub use lapin::{
@@ -279,7 +278,6 @@ struct RabbitMqAcker {
     requeue_on_nack: bool,
 }
 
-#[async_trait]
 impl Acker for RabbitMqAcker {
     async fn ack(&mut self) -> Result<()> {
         self.acker

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -215,13 +215,13 @@ pub struct RabbitMqConsumer {
 
 impl RabbitMqConsumer {
     fn wrap_delivery(&self, delivery: lapin::message::Delivery) -> Delivery {
-        Delivery {
-            payload: Some(delivery.data),
-            acker: Box::new(RabbitMqAcker {
+        Delivery::new(
+            delivery.data,
+            RabbitMqAcker {
                 acker: Some(delivery.acker),
                 requeue_on_nack: self.requeue_on_nack,
-            }),
-        }
+            },
+        )
     }
 
     pub async fn receive(&mut self) -> Result<Delivery> {

--- a/omniqueue/src/backends/redis/fallback.rs
+++ b/omniqueue/src/backends/redis/fallback.rs
@@ -3,7 +3,6 @@
 
 use std::time::Duration;
 
-use async_trait::async_trait;
 use bb8::ManageConnection;
 use redis::AsyncCommands;
 use svix_ksuid::{KsuidLike as _, KsuidMs};
@@ -87,7 +86,6 @@ struct RedisFallbackAcker<M: ManageConnection> {
     already_acked_or_nacked: bool,
 }
 
-#[async_trait]
 impl<R: RedisConnection> Acker for RedisFallbackAcker<R> {
     async fn ack(&mut self) -> Result<()> {
         if self.already_acked_or_nacked {

--- a/omniqueue/src/backends/redis/fallback.rs
+++ b/omniqueue/src/backends/redis/fallback.rs
@@ -68,15 +68,15 @@ async fn receive_with_timeout<R: RedisConnection>(
 fn make_delivery<R: RedisConnection>(consumer: &RedisConsumer<R>, key: &[u8]) -> Result<Delivery> {
     let (_, payload) = from_key(key)?;
 
-    Ok(Delivery {
-        payload: Some(payload.to_owned()),
-        acker: Box::new(RedisFallbackAcker {
+    Ok(Delivery::new(
+        payload.to_owned(),
+        RedisFallbackAcker {
             redis: consumer.redis.clone(),
             processing_queue_key: consumer.processing_queue_key.clone(),
             key: key.to_owned(),
             already_acked_or_nacked: false,
-        }),
-    })
+        },
+    ))
 }
 
 struct RedisFallbackAcker<M: ManageConnection> {

--- a/omniqueue/src/backends/redis/streams.rs
+++ b/omniqueue/src/backends/redis/streams.rs
@@ -2,7 +2,6 @@
 
 use std::time::Duration;
 
-use async_trait::async_trait;
 use bb8::ManageConnection;
 use redis::{
     streams::{StreamClaimReply, StreamId, StreamReadOptions, StreamReadReply},
@@ -134,7 +133,6 @@ struct RedisStreamsAcker<M: ManageConnection> {
     already_acked_or_nacked: bool,
 }
 
-#[async_trait]
 impl<R: RedisConnection> Acker for RedisStreamsAcker<R> {
     async fn ack(&mut self) -> Result<()> {
         if self.already_acked_or_nacked {

--- a/omniqueue/src/backends/redis/streams.rs
+++ b/omniqueue/src/backends/redis/streams.rs
@@ -113,16 +113,16 @@ fn wrap_entry<R: RedisConnection>(
         .ok_or(QueueError::NoData)?;
     let payload: Vec<u8> = redis::from_redis_value(payload).map_err(QueueError::generic)?;
 
-    Ok(Delivery {
-        payload: Some(payload),
-        acker: Box::new(RedisStreamsAcker {
+    Ok(Delivery::new(
+        payload,
+        RedisStreamsAcker {
             redis: consumer.redis.clone(),
             queue_key: consumer.queue_key.to_owned(),
             consumer_group: consumer.consumer_group.to_owned(),
             entry_id,
             already_acked_or_nacked: false,
-        }),
-    })
+        },
+    ))
 }
 
 struct RedisStreamsAcker<M: ManageConnection> {

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -319,15 +319,15 @@ pub struct SqsConsumer {
 
 impl SqsConsumer {
     fn wrap_message(&self, message: &Message) -> Delivery {
-        Delivery {
-            acker: Box::new(SqsAcker {
+        Delivery::new(
+            message.body().unwrap_or_default().as_bytes().to_owned(),
+            SqsAcker {
                 ack_client: self.client.clone(),
                 queue_dsn: self.queue_dsn.clone(),
                 receipt_handle: message.receipt_handle().map(ToOwned::to_owned),
                 has_been_acked_or_nacked: false,
-            }),
-            payload: Some(message.body().unwrap_or_default().as_bytes().to_owned()),
-        }
+            },
+        )
     }
 
     pub async fn receive(&self) -> Result<Delivery> {

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -4,7 +4,6 @@ use std::{
     time::Duration,
 };
 
-use async_trait::async_trait;
 use aws_sdk_sqs::{
     operation::delete_message::DeleteMessageError,
     types::{error::ReceiptHandleIsInvalid, Message},
@@ -191,7 +190,6 @@ struct SqsAcker {
     has_been_acked_or_nacked: bool,
 }
 
-#[async_trait]
 impl Acker for SqsAcker {
     async fn ack(&mut self) -> Result<()> {
         if self.has_been_acked_or_nacked {

--- a/omniqueue/src/queue/acker.rs
+++ b/omniqueue/src/queue/acker.rs
@@ -1,0 +1,64 @@
+use std::{future::Future, pin::Pin, time::Duration};
+
+use crate::Result;
+
+pub(crate) trait Acker: Send {
+    fn ack(&mut self) -> impl Future<Output = Result<()>> + Send;
+    fn nack(&mut self) -> impl Future<Output = Result<()>> + Send;
+    #[cfg_attr(not(feature = "beta"), allow(dead_code))]
+    fn set_ack_deadline(&mut self, duration: Duration) -> impl Future<Output = Result<()>> + Send;
+}
+
+pub(crate) struct DynAcker(Box<dyn ErasedAcker>);
+
+impl DynAcker {
+    pub(super) fn new(inner: impl Acker + 'static) -> Self {
+        let c = DynAckerInner { inner };
+        Self(Box::new(c))
+    }
+}
+
+impl Acker for DynAcker {
+    async fn ack(&mut self) -> Result<()> {
+        self.0.ack().await
+    }
+
+    async fn nack(&mut self) -> Result<()> {
+        self.0.nack().await
+    }
+
+    async fn set_ack_deadline(&mut self, duration: Duration) -> Result<()> {
+        self.0.set_ack_deadline(duration).await
+    }
+}
+
+trait ErasedAcker: Send {
+    fn ack(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
+    fn nack(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
+    #[cfg_attr(not(feature = "beta"), allow(dead_code))]
+    fn set_ack_deadline(
+        &mut self,
+        duration: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
+}
+
+struct DynAckerInner<C> {
+    inner: C,
+}
+
+impl<C: Acker> ErasedAcker for DynAckerInner<C> {
+    fn ack(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async move { self.inner.ack().await })
+    }
+
+    fn nack(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async move { self.inner.nack().await })
+    }
+
+    fn set_ack_deadline(
+        &mut self,
+        duration: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async move { self.inner.set_ack_deadline(duration).await })
+    }
+}

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -44,11 +44,29 @@ pub trait QueueBackend {
 
 /// The output of queue backends
 pub struct Delivery {
-    pub(crate) payload: Option<Vec<u8>>,
-    pub(crate) acker: Box<dyn Acker>,
+    payload: Option<Vec<u8>>,
+    acker: Box<dyn Acker>,
 }
 
 impl Delivery {
+    #[cfg_attr(
+        not(any(
+            feature = "in_memory",
+            feature = "gcp_pubsub",
+            feature = "rabbitmq",
+            feature = "redis",
+            feature = "sqs",
+            feature = "azure_queue_storage"
+        )),
+        allow(dead_code)
+    )]
+    pub(crate) fn new(payload: Vec<u8>, acker: impl Acker + 'static) -> Self {
+        Self {
+            payload: Some(payload),
+            acker: Box::new(acker),
+        }
+    }
+
     /// Acknowledges the receipt and successful processing of this [`Delivery`].
     ///
     /// On failure, `self` is returned alongside the error to allow retrying.


### PR DESCRIPTION
Same as for the public traits.

Rust-analyzer doesn't work so well with `async_trait`. I need to add some new stuff¹ and this was in the way a little bit.

¹ internal ref: https://github.com/svix/monorepo-private/issues/8574