### PR TITLE
Support redis max-attempts

### DIFF
--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -211,6 +211,7 @@ impl InternalPayload {
     fn into_fallback_delivery<R: RedisConnection>(
         self,
         consumer: &RedisConsumer<R>,
+        old_payload: &[u8],
     ) -> Result<Delivery> {
         let InternalPayload {
             payload,
@@ -222,7 +223,7 @@ impl InternalPayload {
             RedisFallbackAcker {
                 redis: consumer.redis.clone(),
                 processing_queue_key: consumer.processing_queue_key.clone(),
-                key: payload.to_owned(),
+                old_payload: old_payload.to_owned(),
                 already_acked_or_nacked: false,
                 max_receives: consumer.max_receives,
                 num_receives,

--- a/omniqueue/src/backends/redis/streams.rs
+++ b/omniqueue/src/backends/redis/streams.rs
@@ -40,7 +40,7 @@ pub(super) async fn send_raw<R: RedisConnection>(
         .xadd(
             &producer.queue_key,
             GENERATE_STREAM_ID,
-            &payload.stream_payload(&producer.payload_key),
+            &payload.into_stream_payload(&producer.payload_key),
         )
         .await
         .map_err(QueueError::generic)
@@ -178,7 +178,7 @@ pub(super) async fn add_to_main_queue(
         let _ = pipe.xadd(
             main_queue_name,
             GENERATE_STREAM_ID,
-            &payload.stream_payload(payload_key),
+            &payload.into_stream_payload(payload_key),
         );
     }
 
@@ -283,7 +283,7 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
             let _ = pipe.xadd(
                 main_queue_name,
                 GENERATE_STREAM_ID,
-                &internal_payload.stream_payload(payload_key),
+                &internal_payload.into_stream_payload(payload_key),
             );
         }
 

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -48,6 +48,7 @@ async fn make_test_queue() -> (RedisBackendBuilder, RedisStreamDrop) {
         consumer_name: "test_cn".to_owned(),
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 5_000,
+        max_receives: None,
     };
 
     (RedisBackend::builder(config), RedisStreamDrop(stream_name))

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -48,6 +48,7 @@ async fn make_test_queue() -> (RedisClusterBackendBuilder, RedisStreamDrop) {
         consumer_name: "test_cn".to_owned(),
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 5_000,
+        max_receives: None,
     };
 
     (

--- a/omniqueue/tests/it/redis_fallback.rs
+++ b/omniqueue/tests/it/redis_fallback.rs
@@ -40,6 +40,7 @@ async fn make_test_queue() -> (RedisBackendBuilder, RedisKeyDrop) {
         consumer_name: "test_cn".to_owned(),
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 5_000,
+        max_receives: None,
     };
 
     (

--- a/omniqueue/tests/it/redis_fallback.rs
+++ b/omniqueue/tests/it/redis_fallback.rs
@@ -290,3 +290,53 @@ async fn test_pending() {
         .unwrap()
         .is_empty());
 }
+
+#[tokio::test]
+async fn test_max_receives() {
+    let payload = ExType { a: 1 };
+
+    let queue_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let max_receives = 5;
+
+    let config = RedisConfig {
+        dsn: ROOT_URL.to_owned(),
+        max_connections: 8,
+        reinsert_on_nack: false,
+        queue_key: queue_key.clone(),
+        delayed_queue_key: format!("{queue_key}::delayed"),
+        delayed_lock_key: format!("{queue_key}::delayed_lock"),
+        consumer_group: "test_cg".to_owned(),
+        consumer_name: "test_cn".to_owned(),
+        payload_key: "payload".to_owned(),
+        ack_deadline_ms: 1,
+        max_receives: Some(max_receives),
+    };
+
+    let (builder, _drop) = (
+        RedisBackend::builder(config).use_redis_streams(false),
+        RedisKeyDrop(queue_key),
+    );
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload).await.unwrap();
+
+    for _ in 0..max_receives {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(&payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+    }
+
+    // Give this some time because the reenqueuing can sleep for up to 500ms
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let delivery = c
+        .receive_all(1, std::time::Duration::from_millis(1))
+        .await
+        .unwrap();
+    assert!(delivery.is_empty());
+}


### PR DESCRIPTION
This adds a `max-attempts` option to both Redis queue implementations.
This is the first step in supporting deadletter queuing. 

An `InternalPayload` type has been added that is shared across both
Redis queue implementations and tracks the number of times
a message has previously been enqueued (i.e., nacked or failed 
processing) and stops re-queuing if that number has been reached.
