### PR TITLE
Support redis `max_receives` config option

### DIFF
--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -48,6 +48,7 @@ async fn make_test_queue() -> (RedisBackendBuilder, RedisStreamDrop) {
         consumer_name: "test_cn".to_owned(),
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 5_000,
+        max_receives: None,
     };
 
     (RedisBackend::builder(config), RedisStreamDrop(stream_name))
@@ -289,4 +290,127 @@ async fn test_pending() {
         .await
         .unwrap()
         .is_empty());
+}
+
+#[tokio::test]
+async fn test_max_receives() {
+    let payload = ExType { a: 1 };
+
+    let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let client = Client::open(ROOT_URL).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+
+    let _: () = conn
+        .xgroup_create_mkstream(&stream_name, "test_cg", 0i8)
+        .await
+        .unwrap();
+
+    let max_receives = 5;
+
+    let config = RedisConfig {
+        dsn: ROOT_URL.to_owned(),
+        max_connections: 8,
+        reinsert_on_nack: false,
+        queue_key: stream_name.clone(),
+        delayed_queue_key: format!("{stream_name}::delayed"),
+        delayed_lock_key: format!("{stream_name}::delayed_lock"),
+        consumer_group: "test_cg".to_owned(),
+        consumer_name: "test_cn".to_owned(),
+        payload_key: "payload".to_owned(),
+        ack_deadline_ms: 1,
+        max_receives: Some(max_receives),
+    };
+
+    let (builder, _drop) = (RedisBackend::builder(config), RedisStreamDrop(stream_name));
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload).await.unwrap();
+
+    for _ in 0..max_receives {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(&payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+    }
+
+    // Give this some time because the reenqueuing can sleep for up to 500ms
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let delivery = c
+        .receive_all(1, std::time::Duration::from_millis(1))
+        .await
+        .unwrap();
+    assert!(delivery.is_empty());
+}
+
+// A message without a `num_receives` field shouldn't
+// cause issues:
+#[tokio::test]
+async fn test_backward_compatible() {
+    let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let client = Client::open(ROOT_URL).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+
+    let _: () = conn
+        .xgroup_create_mkstream(&stream_name, "test_cg", 0i8)
+        .await
+        .unwrap();
+
+    let max_receives = 5;
+
+    let config = RedisConfig {
+        dsn: ROOT_URL.to_owned(),
+        max_connections: 8,
+        reinsert_on_nack: false,
+        queue_key: stream_name.clone(),
+        delayed_queue_key: format!("{stream_name}::delayed"),
+        delayed_lock_key: format!("{stream_name}::delayed_lock"),
+        consumer_group: "test_cg".to_owned(),
+        consumer_name: "test_cn".to_owned(),
+        payload_key: "payload".to_owned(),
+        ack_deadline_ms: 1,
+        max_receives: Some(max_receives),
+    };
+
+    let (builder, _drop) = (
+        RedisBackend::builder(config),
+        RedisStreamDrop(stream_name.clone()),
+    );
+
+    let (_p, mut c) = builder.build_pair().await.unwrap();
+
+    let org_payload = ExType { a: 1 };
+    let org_payload_str = serde_json::to_string(&org_payload).unwrap();
+
+    let _: () = conn
+        .xadd(
+            &stream_name,
+            "*",
+            &[("payload", org_payload_str.as_bytes())],
+        )
+        .await
+        .unwrap();
+
+    for _ in 0..max_receives {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(&org_payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+    }
+
+    // Give this some time because the reenqueuing can sleep for up to 500ms
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let delivery = c
+        .receive_all(1, std::time::Duration::from_millis(1))
+        .await
+        .unwrap();
+    assert!(delivery.is_empty());
 }

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -48,6 +48,7 @@ async fn make_test_queue() -> (RedisClusterBackendBuilder, RedisStreamDrop) {
         consumer_name: "test_cn".to_owned(),
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 5_000,
+        max_receives: None,
     };
 
     (


### PR DESCRIPTION
This adds a `max_receives` option to both Redis queue implementations.
This is the first step in supporting deadletter queuing.

`InternalPayload` type aliases have been added to represent Omniqueue
items that track the current number of times a message has been
received (`num_receives`). `num_receives` is incremented whenever
an item is re-queued from the pending/processing queues until it
hits `max_receives`, at which point the message is abandoned. Later
we will support putting this in an optional deadletter queue.

I originally tried adding a proper struct for `InternalPayload`, but
I don't think that clarified anything and was less memory optimal,
so the relevant logic has been captured in simple functions/macro 
instead.

