### PR TITLE
Support DLQ redrive in redis

### DIFF
--- a/omniqueue/src/backends/azure_queue_storage.rs
+++ b/omniqueue/src/backends/azure_queue_storage.rs
@@ -133,11 +133,17 @@ impl AqsProducer {
         let payload = serde_json::to_string(payload)?;
         self.send_raw_scheduled(&payload, delay).await
     }
+
+    pub async fn redrive_dlq(&self) -> Result<()> {
+        Err(QueueError::Unsupported(
+            "redrive_dlq is not supported by AqsBackend",
+        ))
+    }
 }
 
 impl crate::QueueProducer for AqsProducer {
     type Payload = String;
-    omni_delegate!(send_raw, send_serde_json);
+    omni_delegate!(send_raw, send_serde_json, redrive_dlq);
 }
 impl crate::ScheduledQueueProducer for AqsProducer {
     omni_delegate!(send_raw_scheduled, send_serde_json_scheduled);

--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -166,6 +166,12 @@ impl GcpPubSubProducer {
     pub async fn send_serde_json<P: Serialize + Sync>(&self, payload: &P) -> Result<()> {
         self.send_raw(&serde_json::to_vec(&payload)?).await
     }
+
+    pub async fn redrive_dlq(&self) -> Result<()> {
+        Err(QueueError::Unsupported(
+            "redrive_dlq is not supported by GcpPubSubBackend",
+        ))
+    }
 }
 
 impl std::fmt::Debug for GcpPubSubProducer {
@@ -178,7 +184,7 @@ impl std::fmt::Debug for GcpPubSubProducer {
 
 impl crate::QueueProducer for GcpPubSubProducer {
     type Payload = Payload;
-    omni_delegate!(send_raw, send_serde_json);
+    omni_delegate!(send_raw, send_serde_json, redrive_dlq);
 
     /// This method is overwritten for the Google Cloud Pub/Sub backend to be
     /// more efficient than the default of sequentially publishing `payloads`.

--- a/omniqueue/src/backends/in_memory.rs
+++ b/omniqueue/src/backends/in_memory.rs
@@ -83,11 +83,17 @@ impl InMemoryProducer {
         let payload = serde_json::to_vec(payload)?;
         self.send_raw_scheduled(&payload, delay).await
     }
+
+    pub async fn redrive_dlq(&self) -> Result<()> {
+        Err(QueueError::Unsupported(
+            "redrive_dlq is not supported by InMemoryBackend",
+        ))
+    }
 }
 
 impl crate::QueueProducer for InMemoryProducer {
     type Payload = Vec<u8>;
-    omni_delegate!(send_raw, send_serde_json);
+    omni_delegate!(send_raw, send_serde_json, redrive_dlq);
 }
 impl crate::ScheduledQueueProducer for InMemoryProducer {
     omni_delegate!(send_raw_scheduled, send_serde_json_scheduled);

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -202,11 +202,17 @@ impl RabbitMqProducer {
         let payload = serde_json::to_vec(payload)?;
         self.send_raw_scheduled(&payload, delay).await
     }
+
+    pub async fn redrive_dlq(&self) -> Result<()> {
+        Err(QueueError::Unsupported(
+            "redrive_dlq is not supported by RabbitMqBackend",
+        ))
+    }
 }
 
 impl crate::QueueProducer for RabbitMqProducer {
     type Payload = Vec<u8>;
-    omni_delegate!(send_raw, send_serde_json);
+    omni_delegate!(send_raw, send_serde_json, redrive_dlq);
 }
 impl crate::ScheduledQueueProducer for RabbitMqProducer {
     omni_delegate!(send_raw_scheduled, send_serde_json_scheduled);

--- a/omniqueue/src/backends/redis/fallback.rs
+++ b/omniqueue/src/backends/redis/fallback.rs
@@ -226,7 +226,7 @@ async fn send_to_dlq<R: RedisConnection>(
         .get()
         .await
         .map_err(QueueError::generic)?
-        .lpush(dlq, payload)
+        .rpush(dlq, payload)
         .await
         .map_err(QueueError::generic)?;
 

--- a/omniqueue/src/backends/redis/streams.rs
+++ b/omniqueue/src/backends/redis/streams.rs
@@ -347,7 +347,7 @@ async fn send_to_dlq<R: RedisConnection>(
         .get()
         .await
         .map_err(QueueError::generic)?
-        .lpush(dlq, &payload)
+        .rpush(dlq, &payload)
         .await
         .map_err(QueueError::generic)?;
 

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -355,11 +355,17 @@ impl SqsProducer {
 
         Ok(())
     }
+
+    pub async fn redrive_dlq(&self) -> Result<()> {
+        Err(QueueError::Unsupported(
+            "redrive_dlq is not supported by SqsBackend",
+        ))
+    }
 }
 
 impl crate::QueueProducer for SqsProducer {
     type Payload = String;
-    omni_delegate!(send_raw, send_serde_json);
+    omni_delegate!(send_raw, send_serde_json, redrive_dlq);
 
     /// This method is overwritten for the SQS backend to be more efficient
     /// than the default of sequentially publishing `payloads`.

--- a/omniqueue/src/macros.rs
+++ b/omniqueue/src/macros.rs
@@ -53,6 +53,15 @@ macro_rules! omni_delegate {
             Self::send_serde_json_scheduled(self, payload, delay)
         }
     };
+    ( redrive_dlq ) => {
+        #[deny(unconditional_recursion)] // method call must defer to an inherent method
+        fn redrive_dlq(
+            &self,
+        ) -> impl std::future::Future<Output = Result<()>> + Send {
+            Self::redrive_dlq(self)
+        }
+    };
+
     ( $method1:ident, $($rest:ident),* $(,)? ) => {
         omni_delegate!($method1);
         omni_delegate!($($rest),*);

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -301,65 +301,8 @@ async fn test_pending() {
 #[tokio::test]
 async fn test_deadletter_config() {
     let payload = ExType { a: 1 };
+    let payload_str = serde_json::to_string(&payload).unwrap();
 
-    let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
-        .take(8)
-        .collect();
-
-    let client = Client::open(ROOT_URL).unwrap();
-    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
-
-    let _: () = conn
-        .xgroup_create_mkstream(&stream_name, "test_cg", 0i8)
-        .await
-        .unwrap();
-
-    let max_receives = 5;
-
-    let config = RedisConfig {
-        dsn: ROOT_URL.to_owned(),
-        max_connections: 8,
-        reinsert_on_nack: false,
-        queue_key: stream_name.clone(),
-        delayed_queue_key: format!("{stream_name}::delayed"),
-        delayed_lock_key: format!("{stream_name}::delayed_lock"),
-        consumer_group: "test_cg".to_owned(),
-        consumer_name: "test_cn".to_owned(),
-        payload_key: "payload".to_owned(),
-        ack_deadline_ms: 1,
-        dlq_config: Some(DeadLetterQueueConfig {
-            queue_key: "dlq-key".to_owned(),
-            max_receives,
-        }),
-    };
-
-    let (builder, _drop) = (RedisBackend::builder(config), RedisStreamDrop(stream_name));
-
-    let (p, mut c) = builder.build_pair().await.unwrap();
-
-    p.send_serde_json(&payload).await.unwrap();
-
-    for _ in 0..max_receives {
-        let delivery = c.receive().await.unwrap();
-        assert_eq!(
-            Some(&payload),
-            delivery.payload_serde_json().unwrap().as_ref()
-        );
-    }
-
-    // Give this some time because the reenqueuing can sleep for up to 500ms
-    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-    let delivery = c
-        .receive_all(1, std::time::Duration::from_millis(1))
-        .await
-        .unwrap();
-    assert!(delivery.is_empty());
-}
-
-// A message without a `num_receives` field shouldn't
-// cause issues:
-#[tokio::test]
-async fn test_backward_compatible() {
     let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
         .take(8)
         .collect();
@@ -411,26 +354,16 @@ async fn test_backward_compatible() {
         RedisStreamDrop(stream_name.clone()),
     );
 
-    let (_p, mut c) = builder.build_pair().await.unwrap();
-
-    let org_payload = ExType { a: 1 };
-    let org_payload_str = serde_json::to_string(&org_payload).unwrap();
+    let (p, mut c) = builder.build_pair().await.unwrap();
 
     // Test send to DLQ via `ack_deadline_ms` expiration:
-    let _: () = conn
-        .xadd(
-            &stream_name,
-            "*",
-            &[("payload", org_payload_str.as_bytes())],
-        )
-        .await
-        .unwrap();
+    p.send_serde_json(&payload).await.unwrap();
 
     for _ in 0..max_receives {
         check_dlq(0).await;
         let delivery = c.receive().await.unwrap();
         assert_eq!(
-            Some(&org_payload),
+            Some(&payload),
             delivery.payload_serde_json().unwrap().as_ref()
         );
     }
@@ -445,23 +378,18 @@ async fn test_backward_compatible() {
 
     // Expected message should be on DLQ:
     let res = check_dlq(1).await;
-    assert_eq!(org_payload_str, res.unwrap());
+    assert_eq!(payload_str, res.unwrap());
 
     // Test send to DLQ via explicit `nack`ing:
     let _: () = conn
-        .xadd(
-            &stream_name,
-            "*",
-            &[("payload", org_payload_str.as_bytes())],
-        )
+        .xadd(&stream_name, "*", &[("payload", payload_str.as_bytes())])
         .await
         .unwrap();
 
     for _ in 0..max_receives {
-        check_dlq(0).await;
         let delivery = c.receive().await.unwrap();
         assert_eq!(
-            Some(&org_payload),
+            Some(&payload),
             delivery.payload_serde_json().unwrap().as_ref()
         );
         delivery.nack().await.unwrap();
@@ -477,5 +405,81 @@ async fn test_backward_compatible() {
 
     // Expected message should be on DLQ:
     let res = check_dlq(1).await;
-    assert_eq!(org_payload_str, res.unwrap());
+    assert_eq!(payload_str, res.unwrap());
+}
+
+// A message without a `num_receives` field shouldn't
+// cause issues:
+#[tokio::test]
+async fn test_backward_compatible() {
+    let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let dlq_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let client = Client::open(ROOT_URL).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+
+    let _: () = conn
+        .xgroup_create_mkstream(&stream_name, "test_cg", 0i8)
+        .await
+        .unwrap();
+
+    let max_receives = 5;
+
+    let config = RedisConfig {
+        dsn: ROOT_URL.to_owned(),
+        max_connections: 8,
+        reinsert_on_nack: false,
+        queue_key: stream_name.clone(),
+        delayed_queue_key: format!("{stream_name}::delayed"),
+        delayed_lock_key: format!("{stream_name}::delayed_lock"),
+        consumer_group: "test_cg".to_owned(),
+        consumer_name: "test_cn".to_owned(),
+        payload_key: "payload".to_owned(),
+        ack_deadline_ms: 20,
+        dlq_config: Some(DeadLetterQueueConfig {
+            queue_key: dlq_key.to_owned(),
+            max_receives,
+        }),
+    };
+
+    let (builder, _drop) = (
+        RedisBackend::builder(config),
+        RedisStreamDrop(stream_name.clone()),
+    );
+
+    let (_p, mut c) = builder.build_pair().await.unwrap();
+
+    let org_payload = ExType { a: 1 };
+    let org_payload_str = serde_json::to_string(&org_payload).unwrap();
+
+    let _: () = conn
+        .xadd(
+            &stream_name,
+            "*",
+            // We don't have the `num_receives` field:
+            &[("payload", org_payload_str.as_bytes())],
+        )
+        .await
+        .unwrap();
+
+    for _ in 0..max_receives {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(&org_payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+    }
+
+    // Give this some time because the reenqueuing can sleep for up to 500ms
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    let delivery = c
+        .receive_all(1, std::time::Duration::from_millis(1))
+        .await
+        .unwrap();
+    assert!(delivery.is_empty());
 }

--- a/omniqueue/tests/it/redis.rs
+++ b/omniqueue/tests/it/redis.rs
@@ -87,7 +87,7 @@ async fn test_bytes_send_recv() {
     d.ack().await.unwrap();
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ExType {
     a: u8,
 }
@@ -419,6 +419,101 @@ async fn test_deadletter_config() {
     delivery.ack().await.unwrap();
 
     check_dlq(0).await;
+}
+
+// Assert that ordering is as expected. I don't know
+// that we need to guarantee this in our docs, but it's
+// good to at least validate it for now:
+#[tokio::test]
+async fn test_deadletter_config_order() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let payload3 = ExType { a: 3 };
+
+    let stream_name: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let dlq_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let client = Client::open(ROOT_URL).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+
+    let _: () = conn
+        .xgroup_create_mkstream(&stream_name, "test_cg", 0i8)
+        .await
+        .unwrap();
+
+    let max_receives = 1;
+
+    let config = RedisConfig {
+        dsn: ROOT_URL.to_owned(),
+        max_connections: 8,
+        reinsert_on_nack: false,
+        queue_key: stream_name.clone(),
+        delayed_queue_key: format!("{stream_name}::delayed"),
+        delayed_lock_key: format!("{stream_name}::delayed_lock"),
+        consumer_group: "test_cg".to_owned(),
+        consumer_name: "test_cn".to_owned(),
+        payload_key: "payload".to_owned(),
+        ack_deadline_ms: 20,
+        dlq_config: Some(DeadLetterQueueConfig {
+            queue_key: dlq_key.to_owned(),
+            max_receives,
+        }),
+    };
+
+    let check_dlq = |asserted_len: usize| {
+        let dlq_key = dlq_key.clone();
+        async move {
+            let client = Client::open(ROOT_URL).unwrap();
+            let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+            let mut res: Vec<String> = conn.lrange(&dlq_key, 0, -1).await.unwrap();
+            assert!(res.len() == asserted_len);
+            res.pop()
+        }
+    };
+
+    let (builder, _drop) = (
+        RedisBackend::builder(config),
+        RedisStreamDrop(stream_name.clone()),
+    );
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    // Test send to DLQ via `ack_deadline_ms` expiration:
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    p.send_serde_json(&payload3).await.unwrap();
+
+    for payload in [&payload1, &payload2, &payload3] {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+        delivery.nack().await.unwrap();
+    }
+
+    // Give this some time because the reenqueuing can sleep for up to 500ms
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // Expected messages should be on DLQ:
+    check_dlq(3).await;
+
+    // Redrive DLQ, receive from main queue, ack:
+    p.redrive_dlq().await.unwrap();
+
+    for payload in [&payload1, &payload2, &payload3] {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+        delivery.ack().await.unwrap();
+    }
 }
 
 // A message without a `num_receives` field shouldn't

--- a/omniqueue/tests/it/redis_fallback.rs
+++ b/omniqueue/tests/it/redis_fallback.rs
@@ -410,6 +410,10 @@ async fn test_backward_compatible() {
         .take(8)
         .collect();
 
+    let dlq_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
     let max_receives = 5;
 
     let config = RedisConfig {
@@ -424,7 +428,7 @@ async fn test_backward_compatible() {
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 20,
         dlq_config: Some(DeadLetterQueueConfig {
-            queue_key: "dlq-key".to_owned(),
+            queue_key: dlq_key.to_owned(),
             max_receives,
         }),
     };

--- a/omniqueue/tests/it/redis_fallback.rs
+++ b/omniqueue/tests/it/redis_fallback.rs
@@ -412,6 +412,90 @@ async fn test_deadletter_config() {
     */
 }
 
+#[tokio::test]
+async fn test_deadletter_config_order() {
+    let payload1 = ExType { a: 1 };
+    let payload2 = ExType { a: 2 };
+    let payload3 = ExType { a: 3 };
+
+    let queue_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let dlq_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+
+    let max_receives = 1;
+
+    let config = RedisConfig {
+        dsn: ROOT_URL.to_owned(),
+        max_connections: 8,
+        reinsert_on_nack: false,
+        queue_key: queue_key.clone(),
+        delayed_queue_key: format!("{queue_key}::delayed"),
+        delayed_lock_key: format!("{queue_key}::delayed_lock"),
+        consumer_group: "test_cg".to_owned(),
+        consumer_name: "test_cn".to_owned(),
+        payload_key: "payload".to_owned(),
+        ack_deadline_ms: 1,
+        dlq_config: Some(DeadLetterQueueConfig {
+            queue_key: dlq_key.to_owned(),
+            max_receives,
+        }),
+    };
+
+    let check_dlq = |asserted_len: usize| {
+        let dlq_key = dlq_key.clone();
+        async move {
+            let client = Client::open(ROOT_URL).unwrap();
+            let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+            let mut res: Vec<String> = conn.lrange(&dlq_key, 0, -1).await.unwrap();
+            assert!(res.len() == asserted_len);
+            res.pop()
+        }
+    };
+
+    let (builder, _drop) = (
+        RedisBackend::builder(config).use_redis_streams(false),
+        RedisKeyDrop(queue_key),
+    );
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    // Test send to DLQ via `ack_deadline_ms` expiration:
+    p.send_serde_json(&payload1).await.unwrap();
+    p.send_serde_json(&payload2).await.unwrap();
+    p.send_serde_json(&payload3).await.unwrap();
+
+    for payload in [&payload1, &payload2, &payload3] {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+        delivery.nack().await.unwrap();
+    }
+
+    // Give this some time because the reenqueuing can sleep for up to 500ms
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    // Expected messages should be on DLQ:
+    check_dlq(3).await;
+
+    // Redrive DLQ, receive from main queue, ack:
+    p.redrive_dlq().await.unwrap();
+
+    for payload in [&payload1, &payload2, &payload3] {
+        let delivery = c.receive().await.unwrap();
+        assert_eq!(
+            Some(payload),
+            delivery.payload_serde_json().unwrap().as_ref()
+        );
+        delivery.ack().await.unwrap();
+    }
+}
+
 // A message without a `num_receives` field shouldn't
 // cause issues:
 #[tokio::test]


### PR DESCRIPTION
Support redriving the DLQ directly from the QueueProducer. Is
this a good idea? Sure! Only supported in Redis for now.