### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,4 +63,4 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.18.0
+      - uses: crate-ci/typos@v1.25.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
     - uses: taiki-e/install-action@cargo-hack
 
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
 
     - name: Clippy
       run: cargo hack --each-feature clippy --all-targets -- -D warnings

--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -16,13 +16,13 @@ aws-sdk-sqs = { version = "1.13.0", optional = true }
 azure_storage = { version = "0.20.0", optional = true }
 azure_storage_queues = { version = "0.20.0", optional = true }
 bb8 = { version = "0.8", optional = true }
-bb8-redis = { version = "0.16.0", optional = true }
+bb8-redis = { version = "0.17.0", optional = true }
 bytesize = "1.3.0"
 futures-util = { version = "0.3.28", default-features = false, features = ["async-await", "std"], optional = true }
-google-cloud-googleapis = { version = "0.12.0", optional = true }
-google-cloud-pubsub = { version = "0.24.0", optional = true }
+google-cloud-googleapis = { version = "0.15.0", optional = true }
+google-cloud-pubsub = { version = "0.29.1", optional = true }
 lapin = { version = "2", optional = true }
-redis = { version = "0.26.1", features = ["tokio-comp", "tokio-native-tls-comp", "streams"], optional = true }
+redis = { version = "0.27.2", features = ["tokio-comp", "tokio-native-tls-comp", "streams"], optional = true }
 serde = "1.0.196"
 serde_json = "1"
 svix-ksuid = { version = "0.8.0", optional = true }

--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -324,7 +324,7 @@ impl<R: RedisConnection> RedisBackendBuilder<R> {
         }
     }
 
-    /// Set a custom [`RedisConnection`] mananager to use.
+    /// Set a custom [`RedisConnection`] manager to use.
     ///
     /// This method only makes sense to call if you have a custom connection
     /// manager implementation. For clustered redis, use


### PR DESCRIPTION
There's a new RUSTSEC for tonic <0.12.3. Previous versions of google-cloud-* were depending on tonic 0.10.x.