### PR TITLE
Add redis sentinel support

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -39,6 +39,7 @@ serde = { version = "1.0.196", features = ["derive"] }
 tokio = { version = "1", features = ["macros"] }
 tokio-executor-trait = "2.1"
 tokio-reactor-trait = "1.1"
+rstest = "0.23.0"
 
 [features]
 default = ["in_memory", "gcp_pubsub", "rabbitmq", "redis", "redis_cluster", "sqs"]
@@ -49,6 +50,7 @@ rabbitmq = ["dep:futures-util", "dep:lapin"]
 rabbitmq-with-message-ids = ["rabbitmq", "dep:svix-ksuid"]
 redis = ["dep:bb8", "dep:bb8-redis", "dep:redis", "dep:svix-ksuid"]
 redis_cluster = ["dep:async-trait", "redis", "redis/cluster-async"]
+redis_sentinel = ["dep:async-trait", "redis", "redis/sentinel"]
 sqs = ["dep:aws-config", "dep:aws-sdk-sqs"]
 azure_queue_storage = ["dep:azure_storage", "dep:azure_storage_queues"]
 beta = []

--- a/omniqueue/src/backends/redis/sentinel.rs
+++ b/omniqueue/src/backends/redis/sentinel.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use redis::{
+    sentinel::{SentinelClient, SentinelNodeConnectionInfo, SentinelServerType},
+    ErrorKind, IntoConnectionInfo, RedisError,
+};
+use tokio::sync::Mutex;
+
+// The mutex here is needed b/c there's currently
+// no way to get connections in the redis sentinel client
+// without a mutable reference to the underlying client.
+struct LockedSentinelClient(pub(crate) Mutex<SentinelClient>);
+
+/// ConnectionManager that implements `bb8::ManageConnection` and supports
+/// asynchronous Sentinel connections via `redis::sentinel::SentinelClient`
+pub struct RedisSentinelConnectionManager {
+    client: LockedSentinelClient,
+}
+
+impl RedisSentinelConnectionManager {
+    pub fn new<T: IntoConnectionInfo>(
+        info: Vec<T>,
+        service_name: String,
+        node_connection_info: Option<SentinelNodeConnectionInfo>,
+    ) -> Result<RedisSentinelConnectionManager, RedisError> {
+        Ok(RedisSentinelConnectionManager {
+            client: LockedSentinelClient(Mutex::new(SentinelClient::build(
+                info,
+                service_name,
+                node_connection_info,
+                SentinelServerType::Master,
+            )?)),
+        })
+    }
+}
+
+#[async_trait]
+impl bb8::ManageConnection for RedisSentinelConnectionManager {
+    type Connection = redis::aio::MultiplexedConnection;
+    type Error = RedisError;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        self.client.0.lock().await.get_async_connection().await
+    }
+
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        let pong: String = redis::cmd("PING").query_async(conn).await?;
+        match pong.as_str() {
+            "PONG" => Ok(()),
+            _ => Err((ErrorKind::ResponseError, "ping request").into()),
+        }
+    }
+
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        false
+    }
+}

--- a/omniqueue/tests/it/main.rs
+++ b/omniqueue/tests/it/main.rs
@@ -4,7 +4,7 @@ mod azure_queue_storage;
 mod gcp_pubsub;
 #[cfg(feature = "rabbitmq")]
 mod rabbitmq;
-#[cfg(feature = "redis")]
+#[cfg(any(feature = "redis", feature = "redis_sentinel"))]
 mod redis;
 #[cfg(feature = "redis_cluster")]
 mod redis_cluster;

--- a/omniqueue/tests/it/redis_cluster.rs
+++ b/omniqueue/tests/it/redis_cluster.rs
@@ -54,6 +54,7 @@ async fn make_test_queue() -> (RedisClusterBackendBuilder, RedisStreamDrop) {
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 5_000,
         dlq_config: None,
+        sentinel_config: None,
     };
 
     (
@@ -338,6 +339,7 @@ async fn test_deadletter_config() {
             queue_key: dlq_key.to_owned(),
             max_receives,
         }),
+        sentinel_config: None,
     };
 
     let check_dlq = |asserted_len: usize| {
@@ -462,6 +464,7 @@ async fn test_deadletter_config_order() {
             queue_key: dlq_key.to_owned(),
             max_receives,
         }),
+        sentinel_config: None,
     };
 
     let check_dlq = |asserted_len: usize| {
@@ -551,6 +554,7 @@ async fn test_backward_compatible() {
             queue_key: dlq_key.to_owned(),
             max_receives,
         }),
+        sentinel_config: None,
     };
 
     let (builder, _drop) = (

--- a/omniqueue/tests/it/redis_fallback.rs
+++ b/omniqueue/tests/it/redis_fallback.rs
@@ -49,6 +49,7 @@ async fn make_test_queue() -> (RedisBackendBuilder, RedisKeyDrop) {
         payload_key: "payload".to_owned(),
         ack_deadline_ms: 5_000,
         dlq_config: None,
+        sentinel_config: None,
     };
 
     (
@@ -328,6 +329,7 @@ async fn test_deadletter_config() {
             queue_key: dlq_key.to_owned(),
             max_receives,
         }),
+        sentinel_config: None,
     };
 
     let check_dlq = |asserted_len: usize| {
@@ -443,6 +445,7 @@ async fn test_deadletter_config_order() {
             queue_key: dlq_key.to_owned(),
             max_receives,
         }),
+        sentinel_config: None,
     };
 
     let check_dlq = |asserted_len: usize| {
@@ -525,6 +528,7 @@ async fn test_backward_compatible() {
             queue_key: dlq_key.to_owned(),
             max_receives,
         }),
+        sentinel_config: None,
     };
 
     let (builder, _drop) = (

--- a/testing-docker-compose.yml
+++ b/testing-docker-compose.yml
@@ -78,6 +78,42 @@ services:
     ports:
       - "6385:6379"
 
+  redis-sentinel:
+    image: docker.io/redis:7
+    ports:
+      - "26379:26379"
+    command: >
+      sh -c 'echo "bind 0.0.0.0" > /etc/sentinel.conf &&
+            echo "sentinel monitor master0 redis-master-0 6379 2" >> /etc/sentinel.conf &&
+            echo "sentinel resolve-hostnames yes" >> /etc/sentinel.conf &&
+            echo "sentinel down-after-milliseconds master0 10000" >> /etc/sentinel.conf &&
+            echo "sentinel failover-timeout master0 10000" >> /etc/sentinel.conf &&
+            echo "sentinel parallel-syncs master0 1" >> /etc/sentinel.conf &&
+            redis-sentinel /etc/sentinel.conf'
+
+  redis-master-0:
+    image: docker.io/redis:7
+    ports:
+      - "6387:6379"
+
+  redis-replica-0:
+    image: docker.io/redis:7
+    ports:
+      - "6388:6379"
+    command:
+      [
+        "redis-server",
+        "--appendonly",
+        "yes",
+        "--replicaof",
+        "redis-master-0",
+        "6379",
+        "--repl-diskless-load",
+        "on-empty-db",
+        "--protected-mode",
+        "no"
+      ]
+
   gcp-pubsub:
     image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
     ports:


### PR DESCRIPTION
There are a few breaking changes made to support this.
Most notably, the an optional `SentinelConfig` struct
has been added to the RedisConfig object. It seems like
obfuscating the fields here might be a good idea, but
that's not how we've been rolling thus far with the
config objects.

Also, the `RedisConnection` trait has been redone
to take a `RedisConfig` instead of a DSN in order
to build the connection. Sentinel needs it owing
to the large number of potential config params needed
for Sentinel, and I think this is probably a better
approach anyway. 

The base redis tests (well, most of them) have also
been updated to support testing against either
base Redis or Sentinel. The `rstest` crate has been
added in order to be able to parameterize the tests
sanely. We also use this crate for tests in `redis-rs`,
so I think it's a no-brainer to add here.

