### PR TITLE
Redis Sentinel cleanup

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -35,11 +35,11 @@ tracing = "0.1"
 [dev-dependencies]
 anyhow = "1.0.79"
 fastrand = "2.0.1"
+rstest = "0.23.0"
 serde = { version = "1.0.196", features = ["derive"] }
 tokio = { version = "1", features = ["macros"] }
 tokio-executor-trait = "2.1"
 tokio-reactor-trait = "1.1"
-rstest = "0.23.0"
 
 [features]
 default = ["in_memory", "gcp_pubsub", "rabbitmq", "redis", "redis_cluster", "sqs"]

--- a/omniqueue/tests/it/main.rs
+++ b/omniqueue/tests/it/main.rs
@@ -4,7 +4,7 @@ mod azure_queue_storage;
 mod gcp_pubsub;
 #[cfg(feature = "rabbitmq")]
 mod rabbitmq;
-#[cfg(any(feature = "redis", feature = "redis_sentinel"))]
+#[cfg(feature = "redis")]
 mod redis;
 #[cfg(feature = "redis_cluster")]
 mod redis_cluster;


### PR DESCRIPTION
Follow-up to #107.

We should also move redis configuration to use builder methods like SQS, but that can be a separate PR.