### PR TITLE
Adjust error message for unsupported set_ack_deadline in AQS

### DIFF
--- a/omniqueue/src/backends/azure_queue_storage.rs
+++ b/omniqueue/src/backends/azure_queue_storage.rs
@@ -183,7 +183,7 @@ impl Acker for AqsAcker {
 
     async fn set_ack_deadline(&mut self, _duration: Duration) -> Result<()> {
         Err(QueueError::Unsupported(
-            "set_ack_deadline is not yet supported by InMemoryBackend",
+            "set_ack_deadline is not yet supported by AqsBackend",
         ))
     }
 }


### PR DESCRIPTION
Found while working on https://github.com/svix/monorepo-private/issues/9440.