### PR TITLE
Disable default-features for aws-config

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.79"
 edition = "2021"
 
 [dependencies]
-aws-config = { version = "1.1.5", features = ["behavior-version-latest"], optional = true }
+aws-config = { version = "1.1.5", default-features = false, features = ["behavior-version-latest"], optional = true }
 aws-sdk-sqs = { version = "1.13.0", optional = true }
 azure_storage = { version = "0.21.0", optional = true }
 azure_storage_queues = { version = "0.21.0", optional = true }


### PR DESCRIPTION
We only need the feature we explicitly enabled.