### PR TITLE
deps: remove the legacy rustls feature from aws-sdk-sqs dependency

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 aws-config = { version = "1.1.5", default-features = false, features = ["behavior-version-latest"], optional = true }
-aws-sdk-sqs = { version = "1.13.0", optional = true }
+aws-sdk-sqs = { version = "1.13.0", optional = true, default-features = false, features = ["default-https-client", "rt-tokio"] }
 azure_storage = { version = "0.21.0", optional = true }
 azure_storage_queues = { version = "0.21.0", optional = true }
 bb8 = { version = "0.9.0", optional = true }


### PR DESCRIPTION
See <https://github.com/awslabs/aws-sdk-rust/discussions/1257> for details.

The (default-enabled) `rustls` featur forces `aws-sdk-sqs` to use the very-legacy hyper 0.14.x HTTP client. This change disables it.

Because features are additive, any omniqueue-rs dependencies that want to continue using hyper 0.14.x after upgrading to this version need to also add an explicit dependency on `aws-sdk-sqs = { version = "1.13.0", features = ["rustls"] }` to their applications.

part of svix/monorepo-private#6220