### PR TITLE
Redis fallback: Enqueue processing messages with proper timestamp

### DIFF
--- a/omniqueue/src/backends/redis/fallback.rs
+++ b/omniqueue/src/backends/redis/fallback.rs
@@ -1,7 +1,7 @@
 //! Implementation of the main queue using two lists instead of redis streams,
 //! for compatibility with redis versions older than 6.2.0.
 
-use std::time::Duration;
+use std::{sync::OnceLock, time::Duration};
 
 use bb8::ManageConnection;
 use redis::AsyncCommands;
@@ -10,10 +10,33 @@ use time::OffsetDateTime;
 use tracing::{error, trace, warn};
 
 use super::{
-    internal_from_list, internal_to_list_payload, DeadLetterQueueConfig, InternalPayload,
-    InternalPayloadOwned, RawPayload, RedisConnection, RedisConsumer, RedisProducer,
+    internal_from_list, internal_to_list_payload, list_entry_id, DeadLetterQueueConfig,
+    InternalPayload, InternalPayloadOwned, RawPayload, RedisConnection, RedisConsumer,
+    RedisProducer,
 };
 use crate::{queue::Acker, Delivery, QueueError, Result};
+
+static REFRESH_TIMESTAMP: OnceLock<redis::Script> = OnceLock::new();
+
+fn refresh_timestamp_script() -> &'static redis::Script {
+    REFRESH_TIMESTAMP.get_or_init(|| {
+        redis::Script::new(
+            r"local processing_queue = KEYS[1]
+              local old_payload      = ARGV[1]
+              local refreshed_payload = ARGV[2]
+              redis.call('LPUSH', processing_queue, refreshed_payload)
+              redis.call('LREM',  processing_queue, 1, old_payload)",
+        )
+    })
+}
+
+fn payload_is_older_than(raw_payload: &[u8], threshold: Duration) -> bool {
+    let id = list_entry_id(raw_payload);
+    let threshold_ksuid = KsuidMs::new(Some(OffsetDateTime::now_utc() - threshold), None)
+        .to_string()
+        .into_bytes();
+    id <= threshold_ksuid.as_slice()
+}
 
 pub(super) async fn send_raw<R: RedisConnection>(
     producer: &RedisProducer<R>,
@@ -51,11 +74,9 @@ async fn receive_with_timeout<R: RedisConnection>(
     consumer: &RedisConsumer<R>,
     timeout: Duration,
 ) -> Result<Option<Delivery>> {
-    let payload: Option<Vec<u8>> = consumer
-        .redis
-        .get()
-        .await
-        .map_err(QueueError::generic)?
+    let mut conn = consumer.redis.get().await.map_err(QueueError::generic)?;
+
+    let Some(list_entry): Option<Vec<u8>> = conn
         .brpoplpush(
             &consumer.queue_key,
             &consumer.processing_queue_key,
@@ -65,17 +86,44 @@ async fn receive_with_timeout<R: RedisConnection>(
             timeout.as_secs_f64(),
         )
         .await
-        .map_err(QueueError::generic)?;
+        .map_err(QueueError::generic)?
+    else {
+        return Ok(None);
+    };
 
-    match payload {
-        Some(old_payload) => Some(internal_to_delivery(
-            internal_from_list(&old_payload)?.into(),
-            consumer,
-            old_payload,
-        ))
-        .transpose(),
-        None => Ok(None),
-    }
+    let internal = internal_from_list(&list_entry)?;
+    let num_receives = internal.num_receives;
+    let inner_payload = internal.payload.to_vec();
+
+    // Refresh the timestamp of the item (i.e., reenqueue it with a new id)
+    // in the processing queue if the original message is older than `cutoff`:
+    let cutoff = (consumer.ack_deadline / 2).min(Duration::from_secs(5));
+    let ack_key = if payload_is_older_than(&list_entry, cutoff) {
+        let refreshed = internal_to_list_payload(InternalPayload {
+            payload: &inner_payload,
+            num_receives: num_receives - 1,
+        });
+        refresh_timestamp_script()
+            .key(&consumer.processing_queue_key)
+            .arg(&list_entry)
+            .arg(&refreshed)
+            .invoke_async::<()>(&mut *conn)
+            .await
+            .map_err(QueueError::generic)?;
+        refreshed
+    } else {
+        list_entry
+    };
+
+    Some(internal_to_delivery(
+        InternalPayloadOwned {
+            payload: inner_payload,
+            num_receives,
+        },
+        consumer,
+        ack_key,
+    ))
+    .transpose()
 }
 
 fn internal_to_delivery<R: RedisConnection>(
@@ -195,6 +243,7 @@ pub(super) async fn background_task_processing<R: RedisConnection>(
     processing_queue_key: String,
     ack_deadline_ms: i64,
     dlq_config: Option<DeadLetterQueueConfig>,
+    poll_interval: Duration,
 ) -> Result<()> {
     // FIXME: ack_deadline_ms should be unsigned
     let ack_deadline = Duration::from_millis(ack_deadline_ms as _);
@@ -205,11 +254,12 @@ pub(super) async fn background_task_processing<R: RedisConnection>(
             &processing_queue_key,
             ack_deadline,
             &dlq_config,
+            poll_interval,
         )
         .await
         {
             error!("{err}");
-            tokio::time::sleep(Duration::from_millis(500)).await;
+            tokio::time::sleep(poll_interval).await;
             continue;
         }
     }
@@ -239,6 +289,7 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
     processing_queue_key: &str,
     ack_deadline: Duration,
     dlq_config: &Option<DeadLetterQueueConfig>,
+    poll_interval: Duration,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     const BATCH_SIZE: isize = 50;
 
@@ -246,10 +297,9 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
 
     let keys: Vec<RawPayload> = conn.lrange(processing_queue_key, -1, -1).await?;
 
+    let deadline = OffsetDateTime::now_utc() - ack_deadline;
     // If the key is older than now, it means we should be processing keys
-    let validity_limit = KsuidMs::new(Some(OffsetDateTime::now_utc() - ack_deadline), None)
-        .to_string()
-        .into_bytes();
+    let validity_limit = KsuidMs::new(Some(deadline), None).to_string().into_bytes();
 
     if !keys.is_empty() && keys[0] <= validity_limit {
         let keys: Vec<RawPayload> = conn.lrange(processing_queue_key, -BATCH_SIZE, -1).await?;
@@ -268,6 +318,7 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
                     }
                     _ => {
                         trace!(
+                            ?deadline,
                             num_receives = num_receives,
                             "Pushing back overdue task to queue"
                         );
@@ -282,8 +333,7 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
             }
         }
     } else {
-        // Sleep before attempting to fetch again if nothing was found
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(poll_interval).await;
     }
 
     Ok(())

--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -45,7 +45,7 @@ pub use bb8_redis::RedisConnectionManager;
 use redis::{sentinel::SentinelNodeConnectionInfo, ProtocolVersion, RedisConnectionInfo, TlsMode};
 use redis::{AsyncCommands, ExistenceCheck, SetExpiry, SetOptions};
 use serde::Serialize;
-use svix_ksuid::KsuidLike;
+use svix_ksuid::{KsuidLike, KsuidMs};
 use thiserror::Error;
 use tokio::task::JoinSet;
 use tracing::{debug, error, info, trace, warn};
@@ -160,6 +160,14 @@ impl From<InternalPayload<'_>> for InternalPayloadOwned {
     }
 }
 
+fn list_entry_id(payload: &[u8]) -> &[u8] {
+    let end = payload
+        .iter()
+        .position(|&b| b == b'#' || b == b'|')
+        .unwrap_or(payload.len());
+    &payload[..end]
+}
+
 fn internal_from_list(payload: &[u8]) -> Result<InternalPayload<'_>> {
     // All information is stored in the key in which the ID and the [optional]
     // number of prior receives are separated by a `#`, and the JSON
@@ -172,11 +180,7 @@ fn internal_from_list(payload: &[u8]) -> Result<InternalPayload<'_>> {
         .position(|&byte| byte == b'|')
         .ok_or_else(|| QueueError::Generic("Improper key format".into()))?;
 
-    let id_end_pos = match count_sep_pos {
-        Some(count_sep_pos) if count_sep_pos < payload_sep_pos => count_sep_pos,
-        _ => payload_sep_pos,
-    };
-    let _id = str::from_utf8(&payload[..id_end_pos])
+    let _id = str::from_utf8(list_entry_id(payload))
         .map_err(|_| QueueError::Generic("Non-UTF8 key ID".into()))?;
 
     // This should be backward-compatible with messages that don't include
@@ -352,6 +356,7 @@ pub struct RedisBackendBuilder<R = RedisConnectionManager, S = Static> {
     config: RedisConfig,
     use_redis_streams: bool,
     processing_queue_key: Option<String>,
+    background_task_poll_interval: Option<Duration>,
     _phantom: PhantomData<fn() -> (R, S)>,
 }
 
@@ -367,6 +372,7 @@ impl<R: RedisConnection> RedisBackendBuilder<R> {
             config,
             use_redis_streams: true,
             processing_queue_key: None,
+            background_task_poll_interval: None,
             _phantom: PhantomData,
         }
     }
@@ -376,6 +382,7 @@ impl<R: RedisConnection> RedisBackendBuilder<R> {
             config: self.config,
             use_redis_streams: self.use_redis_streams,
             processing_queue_key: self.processing_queue_key,
+            background_task_poll_interval: self.background_task_poll_interval,
             _phantom: PhantomData,
         }
     }
@@ -406,6 +413,11 @@ impl<R: RedisConnection> RedisBackendBuilder<R> {
     /// queue keys.
     pub fn use_redis_streams(mut self, value: bool) -> Self {
         self.use_redis_streams = value;
+        self
+    }
+
+    pub fn background_task_poll_interval(mut self, interval: Duration) -> Self {
+        self.background_task_poll_interval = Some(interval);
         self
     }
 
@@ -456,6 +468,7 @@ impl<R: RedisConnection> RedisBackendBuilder<R> {
                 consumer_name: self.config.consumer_name,
                 payload_key: self.config.payload_key,
                 use_redis_streams: self.use_redis_streams,
+                ack_deadline: Duration::from_millis(self.config.ack_deadline_ms as u64),
                 _background_tasks: background_tasks.clone(),
                 dlq_config: self.config.dlq_config.clone(),
             },
@@ -501,6 +514,7 @@ impl<R: RedisConnection> RedisBackendBuilder<R> {
             consumer_name: self.config.consumer_name,
             payload_key: self.config.payload_key,
             use_redis_streams: self.use_redis_streams,
+            ack_deadline: Duration::from_millis(self.config.ack_deadline_ms as u64),
             _background_tasks,
             dlq_config: self.config.dlq_config,
         })
@@ -569,12 +583,16 @@ impl<R: RedisConnection> RedisBackendBuilder<R> {
                 self.config.dlq_config.clone(),
             ));
         } else {
+            let poll_interval = self
+                .background_task_poll_interval
+                .unwrap_or(Duration::from_millis(500));
             join_set.spawn(fallback::background_task_processing(
                 redis.clone(),
                 self.config.queue_key.to_owned(),
                 self.get_processing_queue_key(),
                 self.config.ack_deadline_ms,
                 self.config.dlq_config.clone(),
+                poll_interval,
             ));
         }
 
@@ -827,7 +845,7 @@ fn unix_timestamp(time: SystemTime) -> Result<u64, SystemTimeError> {
 /// - don't only get delivered once instead of N times.
 /// - don't replace each other's "delivery due" timestamp.
 fn delayed_key_id() -> String {
-    svix_ksuid::Ksuid::new(None, None).to_base62()
+    KsuidMs::new(None, None).to_string()
 }
 
 pub struct RedisConsumer<M: ManageConnection> {
@@ -838,6 +856,7 @@ pub struct RedisConsumer<M: ManageConnection> {
     consumer_name: String,
     payload_key: String,
     use_redis_streams: bool,
+    ack_deadline: Duration,
     _background_tasks: Arc<JoinSet<Result<()>>>,
     dlq_config: Option<DeadLetterQueueConfig>,
 }

--- a/omniqueue/tests/it/redis_fallback.rs
+++ b/omniqueue/tests/it/redis_fallback.rs
@@ -10,7 +10,7 @@ use omniqueue::{
 };
 use redis::{AsyncCommands, Client, Commands};
 use serde::{Deserialize, Serialize};
-use svix_ksuid::KsuidLike;
+use svix_ksuid::KsuidLike as _;
 
 const ROOT_URL: &str = "redis://localhost";
 
@@ -567,4 +567,85 @@ async fn test_backward_compatible() {
         .await
         .unwrap();
     assert!(delivery.is_empty());
+}
+
+async fn make_test_queue_with_deadline(
+    ack_deadline_ms: i64,
+    dlq_config: Option<DeadLetterQueueConfig>,
+) -> (RedisBackendBuilder, String, RedisKeyDrop) {
+    let queue_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+    let config = RedisConfig {
+        dsn: ROOT_URL.to_owned(),
+        max_connections: 8,
+        reinsert_on_nack: false,
+        queue_key: queue_key.clone(),
+        delayed_queue_key: format!("{queue_key}::delayed"),
+        delayed_lock_key: format!("{queue_key}::delayed_lock"),
+        consumer_group: "test_cg".to_owned(),
+        consumer_name: "test_cn".to_owned(),
+        payload_key: "payload".to_owned(),
+        ack_deadline_ms,
+        dlq_config,
+        sentinel_config: None,
+    };
+    let processing_queue_key = format!("{queue_key}_processing");
+    (
+        RedisBackend::builder(config)
+            .use_redis_streams(false)
+            .background_task_poll_interval(Duration::from_millis(10)),
+        processing_queue_key,
+        RedisKeyDrop(queue_key),
+    )
+}
+
+#[tokio::test]
+async fn test_ack_deadline_processing() {
+    let ack_deadline_ms: i64 = 500;
+    let payload = ExType { a: 42 };
+
+    let (builder, _processing_queue_key, _drop) =
+        make_test_queue_with_deadline(ack_deadline_ms, None).await;
+
+    let (p, mut c) = builder.build_pair().await.unwrap();
+
+    p.send_serde_json(&payload).await.unwrap();
+
+    // Let the message age past the refresh threshold before receiving
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Dequeue -- message should get new timestamp in processing queue
+    let delivery = c.receive().await.unwrap();
+    assert_eq!(
+        Some(&payload),
+        delivery.payload_serde_json().unwrap().as_ref()
+    );
+    drop(delivery);
+
+    // Still in processing after 250 ms
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert!(c
+        .receive_all(1, Duration::from_millis(10))
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Past the deadline — should be requeued
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let delivery = c.receive_all(1, Duration::from_millis(50)).await.unwrap();
+    assert_eq!(1, delivery.len());
+    assert_eq!(
+        Some(&payload),
+        delivery[0].payload_serde_json().unwrap().as_ref()
+    );
+    delivery.into_iter().next().unwrap().ack().await.unwrap();
+
+    // Should still be empty
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert!(c
+        .receive_all(1, Duration::from_millis(10))
+        .await
+        .unwrap()
+        .is_empty());
 }


### PR DESCRIPTION
This works around an issue (#102) with the redis fallback implementation
where messages that were slow to be dequeued were put back into
the main queue too soon. Why? Because the background task that monitors
the processing queue uses the timestamp of the message when deciding
whether the message is due for re-queueing. This timestamp is determined
at initial enqueue time.

Unfortunately, it's not an easy fix to just update the timestamp
when we move the message to the processing queue because because
we depend on both the blocking and atomic nature of `brpoplpush`
for de-queuing. So, rather than try a more significant re-architecture,
we "patch" messages whose initial timestamp is above a certain
threshold at the time they are dequeued from the main queue.

This doesn't completely eliminate the issue but ameliorates it so
that we avoid a worst-case of messages being immediately put back
into the main queue after de-queueing, which is what we were seeing
in cases when environments were under heavy load.
