### PR TITLE
Redis fallback: Don't reenqueue duplicate delayed messages

### DIFF
--- a/omniqueue/src/backends/redis/fallback.rs
+++ b/omniqueue/src/backends/redis/fallback.rs
@@ -17,6 +17,7 @@ use super::{
 use crate::{queue::Acker, Delivery, QueueError, Result};
 
 static REFRESH_TIMESTAMP: OnceLock<redis::Script> = OnceLock::new();
+static REENQUEUE_SCRIPT: OnceLock<redis::Script> = OnceLock::new();
 
 fn refresh_timestamp_script() -> &'static redis::Script {
     REFRESH_TIMESTAMP.get_or_init(|| {
@@ -26,6 +27,27 @@ fn refresh_timestamp_script() -> &'static redis::Script {
               local refreshed_payload = ARGV[2]
               redis.call('LPUSH', processing_queue, refreshed_payload)
               redis.call('LREM',  processing_queue, 1, old_payload)",
+        )
+    })
+}
+
+fn reenqueue_script() -> &'static redis::Script {
+    REENQUEUE_SCRIPT.get_or_init(|| {
+        // RPUSH before LREM so a crash never loses the message (it ends up in
+        // both queues rather than neither). If LREM returns 0, another process
+        // already handled this item, so we undo our RPUSH. new_payload carries
+        // a unique KSUID so the undo-LREM only removes the payload we just pushed.
+        redis::Script::new(
+            "local processing_queue = KEYS[1]
+             local dest_queue       = KEYS[2]
+             local old_payload      = ARGV[1]
+             local new_payload      = ARGV[2]
+             redis.call('RPUSH', dest_queue, new_payload)
+             local removed = redis.call('LREM', processing_queue, 1, old_payload)
+             if removed == 0 then
+                 redis.call('LREM', dest_queue, 1, new_payload)
+             end
+             return removed",
         )
     })
 }
@@ -314,7 +336,13 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
                             num_receives = num_receives,
                             "Maximum attempts reached for message, moving item to DLQ",
                         );
-                        send_to_dlq(pool, dlq_config, internal.payload).await?;
+                        reenqueue_script()
+                            .key(processing_queue_key)
+                            .key(&dlq_config.queue_key)
+                            .arg(&key)
+                            .arg(internal.payload)
+                            .invoke_async::<()>(&mut *conn)
+                            .await?;
                     }
                     _ => {
                         trace!(
@@ -322,14 +350,15 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
                             num_receives = num_receives,
                             "Pushing back overdue task to queue"
                         );
-                        let _: () = conn
-                            .rpush(queue_key, internal_to_list_payload(internal))
+                        reenqueue_script()
+                            .key(processing_queue_key)
+                            .key(queue_key)
+                            .arg(&key)
+                            .arg(internal_to_list_payload(internal))
+                            .invoke_async::<()>(&mut *conn)
                             .await?;
                     }
                 }
-
-                // We use LREM to be sure we only delete the keys we should be deleting
-                let _: () = conn.lrem(processing_queue_key, 1, &key).await?;
             }
         }
     } else {

--- a/omniqueue/tests/it/redis_fallback.rs
+++ b/omniqueue/tests/it/redis_fallback.rs
@@ -649,3 +649,57 @@ async fn test_ack_deadline_processing() {
         .unwrap()
         .is_empty());
 }
+
+#[tokio::test]
+async fn test_concurrent_reenqueue_no_duplicates() {
+    let queue_key: String = std::iter::repeat_with(fastrand::alphanumeric)
+        .take(8)
+        .collect();
+    let processing_key = format!("{queue_key}_processing");
+    let ack_deadline_ms: i64 = 200;
+
+    let make_builder = || {
+        let config = RedisConfig {
+            dsn: ROOT_URL.to_owned(),
+            max_connections: 8,
+            reinsert_on_nack: false,
+            queue_key: queue_key.clone(),
+            delayed_queue_key: format!("{queue_key}::delayed"),
+            delayed_lock_key: format!("{queue_key}::delayed_lock"),
+            consumer_group: "test_cg".to_owned(),
+            consumer_name: "test_cn".to_owned(),
+            payload_key: "payload".to_owned(),
+            ack_deadline_ms,
+            dlq_config: None,
+            sentinel_config: None,
+        };
+        RedisBackend::builder(config)
+            .use_redis_streams(false)
+            .processing_queue_key(processing_key.clone())
+            .background_task_poll_interval(Duration::from_millis(10))
+    };
+
+    // 20 concurrent workers
+    let (p, mut c) = make_builder().build_pair().await.unwrap();
+    let mut extra: Vec<_> = Vec::new();
+    for _ in 0..19 {
+        extra.push(make_builder().build_pair().await.unwrap());
+    }
+
+    p.send_raw(b"test payload").await.unwrap();
+    drop(c.receive().await.unwrap());
+
+    tokio::time::sleep(Duration::from_millis(ack_deadline_ms as u64 + 200)).await;
+
+    let mut conn = Client::open(ROOT_URL)
+        .unwrap()
+        .get_multiplexed_async_connection()
+        .await
+        .unwrap();
+    let main_len: isize = conn.llen(&queue_key).await.unwrap();
+    let proc_len: isize = conn.llen(&processing_key).await.unwrap();
+    let _: () = conn.del(&[&queue_key, &processing_key]).await.unwrap();
+
+    assert_eq!(main_len, 1);
+    assert_eq!(proc_len, 0);
+}


### PR DESCRIPTION
Another issue recently encountered. The existing implementation is heavily subject to races between multiple workers. Now, we use Lua to reenqueue the message, remove it from the old queue, and delete the reenqueued message if another thread has already done so. This is not the prettiest way to handle this but ensures that we never remove the old message before enqueuing, even in the otherwise atomic Lua script.