### PR TITLE
ci: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
-        # only restore cache for faster publishing, don't save back results
-        save-if: false
-
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 


### PR DESCRIPTION
save-if would have to be nested under 'with'.
But also, the cache is job-specific so never saving it means it never gets used, so might as well remove it.