### PR TITLE
Upgrade svix-ksuid to 0.10 and drop time dependency

### DIFF
--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -24,10 +24,9 @@ lapin = { version = "3.0.0", optional = true }
 redis = { version = "0.32.1", features = ["tokio-comp", "tokio-native-tls-comp", "streams"], optional = true }
 serde = "1.0.196"
 serde_json = "1"
-svix-ksuid = { version = "0.9.0", optional = true }
+svix-ksuid = { version = "0.10.0", default-features = false, optional = true }
 sync_wrapper = "1.0.1"
 thiserror = "2.0"
-time = "0.3.34"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = "0.1"
 

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -140,9 +140,8 @@ impl RabbitMqProducer {
         #[cfg(feature = "rabbitmq-with-message-ids")]
         {
             use svix_ksuid::{KsuidLike as _, KsuidMs};
-            use time::OffsetDateTime;
 
-            let id = &KsuidMs::new(Some(OffsetDateTime::now_utc()), None);
+            let id = KsuidMs::now(None);
             properties = properties.with_message_id(id.to_string().into());
         }
         if let Some(headers) = headers {

--- a/omniqueue/src/backends/redis/fallback.rs
+++ b/omniqueue/src/backends/redis/fallback.rs
@@ -1,12 +1,14 @@
 //! Implementation of the main queue using two lists instead of redis streams,
 //! for compatibility with redis versions older than 6.2.0.
 
-use std::{sync::OnceLock, time::Duration};
+use std::{
+    sync::OnceLock,
+    time::{Duration, SystemTime},
+};
 
 use bb8::ManageConnection;
 use redis::AsyncCommands;
 use svix_ksuid::{KsuidLike as _, KsuidMs};
-use time::OffsetDateTime;
 use tracing::{error, trace, warn};
 
 use super::{
@@ -54,7 +56,7 @@ fn reenqueue_script() -> &'static redis::Script {
 
 fn payload_is_older_than(raw_payload: &[u8], threshold: Duration) -> bool {
     let id = list_entry_id(raw_payload);
-    let threshold_ksuid = KsuidMs::new(Some(OffsetDateTime::now_utc() - threshold), None)
+    let threshold_ksuid = KsuidMs::new(Some(SystemTime::now() - threshold), None)
         .to_string()
         .into_bytes();
     id <= threshold_ksuid.as_slice()
@@ -319,7 +321,7 @@ async fn reenqueue_timed_out_messages<R: RedisConnection>(
 
     let keys: Vec<RawPayload> = conn.lrange(processing_queue_key, -1, -1).await?;
 
-    let deadline = OffsetDateTime::now_utc() - ack_deadline;
+    let deadline = SystemTime::now() - ack_deadline;
     // If the key is older than now, it means we should be processing keys
     let validity_limit = KsuidMs::new(Some(deadline), None).to_string().into_bytes();
 


### PR DESCRIPTION
~Wondering why `svix_ksuid::TimeStamp` isn't implemented for `SystemTime`.~