### PR TITLE
sec: update cargo-deny config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,10 +11,8 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 ignore = [
-    # TODO: Wait for dependencies to upgrade off of paste
-    "RUSTSEC-2024-0436",
-    # TODO: Wait for dependencies to upgrade off of rustls-pemfile (unmaintained)
-    "RUSTSEC-2025-0134",
+  # this is unreachable in this code
+  "RUSTSEC-2026-0174"
 ]
 
 [licenses]
@@ -25,8 +23,6 @@ allow = [
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
-    "MPL-2.0",
-    "OpenSSL",
     "Unicode-3.0",
 ]
 confidence-threshold = 0.8
@@ -34,28 +30,12 @@ exceptions = [
     #{ allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
-[[licenses.clarify]]
-name = "ring"
-version = "*"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
-]
-
-[[licenses.clarify]]
-name = "encoding_rs"
-version = "0.8.30"
-expression = "MIT OR Apache-2.0"
-license-files = [
-    { path = "COPYRIGHT", hash = 0x39f8ad31 }
-]
-
 [licenses.private]
 ignore = false
 registries = []
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "allow"
 wildcards = "allow"
 highlight = "all"
 allow = []

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 ignore = [
+  # azure_core (used if the `azure_queue_storage` feature is enabled) still uses paste
+  "RUSTSEC-2024-0436",
   # this is unreachable in this code
   "RUSTSEC-2026-0174"
 ]


### PR DESCRIPTION
removes some unused stuff; adds a new unactionable advisory to ignore.