### PR TITLE
Remove obsolete version attribute from testing compose file

### DIFF
--- a/testing-docker-compose.yml
+++ b/testing-docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   rabbitmq:
     image: docker.io/rabbitmq:3.11.11-management-alpine


### PR DESCRIPTION
This is my first PR to the repo. Since the change is small, I opened a PR directly instead of filing an issue first. If that is not the preferred approach here, let me know.

**What I found**

While setting up the project locally and starting the test dependencies with:

docker compose -f ./testing-docker-compose.yml up -d

Docker Compose prints a warning on every run:

WARN[0000] .../testing-docker-compose.yml: the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion

<img width="1762" height="421" alt="Screenshot from 2026-07-08 13-15-29" src="https://github.com/user-attachments/assets/f91acad1-80b0-49d9-9871-5732f4035b0e" />

**Why it happens**

The top-level `version` field is obsolete in the Compose Specification and is completely ignored by Docker Compose v2. The same warning also appears in CI, in the "Start test dependencies" step.

**The fix**

This PR removes that single line. There is no change in behavior, all services still start identically. It only silences the warning and keeps the output clean.

<img width="1294" height="296" alt="Screenshot from 2026-07-08 13-17-46" src="https://github.com/user-attachments/assets/29ef95ab-2748-4c75-b7c6-172cf2eaffc0" />