### PR TITLE
Document each backend's configuration and construction

### DIFF
--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -1,3 +1,54 @@
+//! Google Cloud Pub/Sub queue implementation.
+//!
+//! # The Implementation
+//!
+//! Pub/Sub splits the two halves of a queue. Producers publish to a topic, and
+//! consumers read from a subscription attached to that topic, so both are named
+//! separately in [`GcpPubSubConfig`].
+//!
+//! Omniqueue creates neither. Both have to exist already, though neither is
+//! checked when the queue is built. A producer whose topic is missing is built
+//! with a warning and only fails once it tries to publish, which leaves room
+//! for the topic to turn up in the meantime. A consumer fails when it tries to
+//! receive from a subscription that is not there.
+//!
+//! Nacking a delivery asks for it to be redelivered right away, rather than
+//! waiting out the ack deadline.
+//!
+//! # Authentication
+//!
+//! Credentials come from the file named by
+//! [`credentials_file`][GcpPubSubConfig::credentials_file], or, when that is
+//! `None`, from the environment: `GOOGLE_APPLICATION_CREDENTIALS` holding a
+//! path to a credentials file, or `GOOGLE_APPLICATION_CREDENTIALS_JSON` holding
+//! the contents of one, so no file is needed on disk.
+//!
+//! # Unsupported Operations
+//!
+//! This is the one backend that cannot send with a delay, so it does not
+//! implement [`ScheduledQueueProducer`][crate::ScheduledQueueProducer].
+//!
+//! `QueueProducer::redrive_dlq` returns [`QueueError::Unsupported`]. Pub/Sub
+//! can dead-letter messages, but that is configured on the subscription, not
+//! through omniqueue.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # async {
+//! use omniqueue::backends::{GcpPubSubBackend, GcpPubSubConfig};
+//!
+//! let cfg = GcpPubSubConfig {
+//!     topic_id: "my-topic".to_owned(),
+//!     subscription_id: "my-subscription".to_owned(),
+//!     credentials_file: None,
+//! };
+//!
+//! let (p, mut c) = GcpPubSubBackend::builder(cfg).build_pair().await?;
+//! # anyhow::Ok(())
+//! # };
+//! ```
+
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -37,8 +88,22 @@ type Payload = Vec<u8>;
 // FIXME: topic/subscription are each for read/write. Split config up?
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GcpPubSubConfig {
+    /// The ID of the topic to publish to, used by the producer.
+    ///
+    /// This is the short ID, not the fully qualified
+    /// `projects/{project}/topics/{topic}` name.
     pub topic_id: String,
+
+    /// The ID of the subscription to consume from, used by the consumer.
+    ///
+    /// It has to be attached to the topic you expect to read from. Nothing
+    /// checks that it is the same topic named above.
     pub subscription_id: String,
+
+    /// Path to a Google Cloud credentials file.
+    ///
+    /// When `None`, credentials are read from the environment instead. See the
+    /// [module docs][self] for which variables are used.
     pub credentials_file: Option<PathBuf>,
 }
 

--- a/omniqueue/src/backends/in_memory.rs
+++ b/omniqueue/src/backends/in_memory.rs
@@ -1,3 +1,36 @@
+//! In-memory queue implementation, meant for tests and local development.
+//!
+//! # The Implementation
+//!
+//! Messages are passed over an unbounded in-process channel. Nothing is
+//! persisted, and no other process can see the queue. There is nothing to
+//! configure, so [`InMemoryBackend::builder`] takes no arguments.
+//!
+//! The producer and consumer are the two ends of one channel, so they can only
+//! be created together. `build_producer` and `build_consumer` both return
+//! [`QueueError::CannotCreateHalf`]. Use `build_pair` instead.
+//!
+//! Nacking a delivery puts it back at the end of the queue. Sending with a
+//! delay spawns a task that waits and then sends, so it needs a tokio runtime
+//! running, and a message still waiting out its delay when the process ends is
+//! lost.
+//!
+//! # Unsupported Operations
+//!
+//! `Delivery::set_ack_deadline` and `QueueProducer::redrive_dlq` both return
+//! [`QueueError::Unsupported`].
+//!
+//! # Example
+//!
+//! ```
+//! # async {
+//! use omniqueue::backends::InMemoryBackend;
+//!
+//! let (p, mut c) = InMemoryBackend::builder().build_pair().await?;
+//! # anyhow::Ok(())
+//! # };
+//! ```
+
 use std::time::{Duration, Instant};
 
 use serde::Serialize;

--- a/omniqueue/src/backends/rabbitmq.rs
+++ b/omniqueue/src/backends/rabbitmq.rs
@@ -1,3 +1,71 @@
+//! RabbitMQ queue implementation.
+//!
+//! # The Implementation
+//!
+//! Producers publish to an exchange with a routing key, and consumers read from
+//! a queue. Omniqueue declares no exchanges, queues or bindings, so they have
+//! to exist before a producer or consumer is built.
+//!
+//! Nacking uses `basic.nack`, and
+//! [`requeue_on_nack`][RabbitMqConfig::requeue_on_nack] decides whether the
+//! message goes back on the queue or is discarded.
+//!
+//! # Scheduled Messages
+//!
+//! Sending with a delay only works if the broker has the
+//! [delayed message exchange plugin][plugin] enabled and
+//! [`publish_exchange`][RabbitMqConfig::publish_exchange] names an exchange
+//! declared with the type `x-delayed-message`.
+//!
+//! The delay is passed as an `x-delay` header. A broker without the plugin
+//! ignores that header and delivers the message immediately instead of failing,
+//! so set the exchange up before relying on delays.
+//!
+//! [plugin]: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange
+//!
+//! # Unsupported Operations
+//!
+//! `Delivery::set_ack_deadline` and `QueueProducer::redrive_dlq` both return
+//! [`QueueError::Unsupported`]. To dead-letter messages, configure a
+//! dead-letter exchange on the queue and set `requeue_on_nack` to `false`.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # async {
+//! use omniqueue::backends::{
+//!     rabbitmq::{
+//!         BasicConsumeOptions, BasicProperties, BasicPublishOptions, ConnectionProperties,
+//!         FieldTable,
+//!     },
+//!     RabbitMqBackend, RabbitMqConfig,
+//! };
+//!
+//! let cfg = RabbitMqConfig {
+//!     uri: "amqp://guest:guest@localhost:5672/%2f".to_owned(),
+//!     connection_properties: ConnectionProperties::default(),
+//!
+//!     // The empty exchange is the default exchange, which routes to the queue
+//!     // named by the routing key.
+//!     publish_exchange: String::new(),
+//!     publish_routing_key: "my-queue".to_owned(),
+//!     publish_options: BasicPublishOptions::default(),
+//!     publish_properties: BasicProperties::default(),
+//!
+//!     consume_queue: "my-queue".to_owned(),
+//!     consumer_tag: "my-consumer".to_owned(),
+//!     consume_options: BasicConsumeOptions::default(),
+//!     consume_arguments: FieldTable::default(),
+//!
+//!     consume_prefetch_count: Some(32),
+//!     requeue_on_nack: true,
+//! };
+//!
+//! let (p, mut c) = RabbitMqBackend::builder(cfg).build_pair().await?;
+//! # anyhow::Ok(())
+//! # };
+//! ```
+
 use std::time::{Duration, Instant};
 
 use futures_util::{FutureExt, StreamExt};
@@ -21,20 +89,68 @@ use crate::{
 
 #[derive(Clone)]
 pub struct RabbitMqConfig {
+    /// The AMQP URI of the broker, for example
+    /// `amqp://guest:guest@localhost:5672/%2f`, where `%2f` is the URL-encoded
+    /// name of the default virtual host, `/`.
     pub uri: String,
+
+    /// Connection-level options handed to [`lapin`], such as which executor to
+    /// run the connection on. [`ConnectionProperties::default()`] is a
+    /// reasonable starting point.
     pub connection_properties: ConnectionProperties,
 
+    /// The exchange to publish to.
+    ///
+    /// The empty string is the default exchange, which routes to the queue
+    /// named by [`publish_routing_key`][Self::publish_routing_key]. Scheduled
+    /// sends need an exchange of type `x-delayed-message`. See the
+    /// [module docs][self].
     pub publish_exchange: String,
+
+    /// The routing key to publish with.
+    ///
+    /// How it is interpreted is up to the exchange. On the default exchange it
+    /// is the name of the destination queue.
     pub publish_routing_key: String,
+
+    /// Options for every `basic.publish`, such as whether an unroutable message
+    /// is returned rather than dropped.
     pub publish_options: BasicPublishOptions,
+
+    /// AMQP properties set on every published message, such as the content type
+    /// or the delivery mode. Scheduled sends add an `x-delay` header on top of
+    /// these.
     pub publish_properties: BasicProperties,
 
+    /// The name of the queue to consume from. It has to exist already.
     pub consume_queue: String,
+
+    /// The tag identifying this consumer to the broker. An empty string lets
+    /// the broker generate one.
     pub consumer_tag: String,
+
+    /// Options for `basic.consume`.
+    ///
+    /// Leave `no_ack` off (the default) to acknowledge deliveries yourself.
+    /// With `no_ack` on, the broker treats a message as delivered as soon as it
+    /// is sent, and acking or nacking it has no effect.
     pub consume_options: BasicConsumeOptions,
+
+    /// Extra arguments passed to `basic.consume`, for example to set a consumer
+    /// priority.
     pub consume_arguments: FieldTable,
 
+    /// How many unacknowledged messages the broker may have in flight to this
+    /// consumer, set via `basic.qos`.
+    ///
+    /// `None` means no limit, which lets the broker push a whole backlog at one
+    /// consumer, so it is usually worth setting.
     pub consume_prefetch_count: Option<u16>,
+
+    /// Whether nacking a delivery puts it back on the queue.
+    ///
+    /// If `false`, a nacked message is discarded, or dead-lettered if the queue
+    /// has a dead-letter exchange configured.
     pub requeue_on_nack: bool,
 }
 

--- a/omniqueue/src/backends/redis/mod.rs
+++ b/omniqueue/src/backends/redis/mod.rs
@@ -27,6 +27,38 @@
 //! set for tasks that should be processed now, and the currently processing
 //! queue for tasks that have timed out and should be put back on the main
 //! queue.
+//!
+//! # Configuration
+//!
+//! Parts of [`RedisConfig`] only apply to one of the two implementations.
+//! [`consumer_group`][RedisConfig::consumer_group],
+//! [`consumer_name`][RedisConfig::consumer_name] and
+//! [`payload_key`][RedisConfig::payload_key] are read by the streams
+//! implementation and ignored by the fallback one. The processing queue, set
+//! with [`processing_queue_key`][RedisBackendBuilder::processing_queue_key],
+//! only exists in the fallback implementation.
+//!
+//! The server must also not be able to evict queue keys, or messages are
+//! silently lost. Omniqueue checks `maxmemory-policy` on startup and logs a
+//! warning if it is not `noeviction` or one of the `volatile-*` policies.
+//!
+//! # Acknowledgements
+//!
+//! Acking a delivery removes it from the queue for good.
+//!
+//! Nacking one does not put it back right away. The message stays where it is,
+//! and the background worker hands it out again once
+//! [`ack_deadline_ms`][RedisConfig::ack_deadline_ms] has passed since it was
+//! last received. A delivery that is simply dropped is redelivered the same
+//! way, so a worker that dies mid-message does not take the message with it.
+//!
+//! With a [`DeadLetterQueueConfig`], a message received
+//! [`max_receives`][DeadLetterQueueConfig::max_receives] times is moved to the
+//! dead-letter queue instead of being handed out again. This is the only
+//! backend where `QueueProducer::redrive_dlq` does anything: it moves every
+//! message in the dead-letter queue back onto the main one. Without that
+//! config, it returns [`QueueError::Unsupported`], as does
+//! `Delivery::set_ack_deadline` in both implementations.
 
 // This lint warns on `let _: () = ...` which is used throughout this file for Redis commands which
 // have generic return types. This is cleaner than the turbofish operator in my opinion.
@@ -262,34 +294,89 @@ async fn check_eviction_policy<R: RedisConnection>(
 }
 
 pub struct RedisConfig {
+    /// The connection string of the redis server, for example
+    /// `redis://localhost:6379`. When connecting through sentinel, this is the
+    /// address of the sentinel instead.
     pub dsn: String,
+
+    /// The largest number of connections to keep in the pool.
     pub max_connections: u16,
+
+    /// Currently unused. Nacking never reinserts a message directly, whatever
+    /// this is set to. See the [module docs][self] for what a nack does
+    /// instead.
     pub reinsert_on_nack: bool,
+
+    /// The key of the main queue: the stream, or the list if you turn streams
+    /// off.
     pub queue_key: String,
+
+    /// The key of the sorted set that holds messages waiting out a delay.
+    ///
+    /// Delayed sending needs this. Left empty, the worker that moves due
+    /// messages onto the main queue is never started, so a delayed send is
+    /// accepted but never delivered. Omniqueue logs a warning when that
+    /// happens.
     pub delayed_queue_key: String,
+
+    /// The key of the lock that keeps two workers from moving the same delayed
+    /// messages onto the main queue at once. It expires by itself, so a worker
+    /// that dies while holding it does not stall the others.
     pub delayed_lock_key: String,
+
+    /// The consumer group that consumers read the stream as. Streams only.
     pub consumer_group: String,
+
+    /// The name identifying this consumer within the consumer group. Streams
+    /// only.
     pub consumer_name: String,
+
+    /// The field a payload is stored under inside a stream entry. Streams only.
     pub payload_key: String,
+
+    /// How long a message may go unacknowledged, in milliseconds, before it is
+    /// handed out again. Set it comfortably longer than a message takes to
+    /// process.
     pub ack_deadline_ms: i64,
+
+    /// Where to put messages that have been received too many times. `None`
+    /// keeps redelivering them forever.
     pub dlq_config: Option<DeadLetterQueueConfig>,
+
+    /// Settings for connecting through redis sentinel.
+    ///
+    /// Only read when the backend is built with
+    /// `RedisBackend::sentinel_builder`, behind the `redis_sentinel` feature,
+    /// which fails without it.
     pub sentinel_config: Option<SentinelConfig>,
 }
 
 #[derive(Clone)]
 pub struct SentinelConfig {
+    /// The name the sentinel knows the redis server by.
     pub service_name: String,
+
+    /// Whether to connect to the redis server behind the sentinel over TLS.
     pub redis_tls_mode_secure: bool,
+
+    /// The database number to select on the redis server. Defaults to 0.
     pub redis_db: Option<i64>,
+
+    /// The username to authenticate to the redis server with, if it needs one.
     pub redis_username: Option<String>,
+
+    /// The password to authenticate to the redis server with, if it needs one.
     pub redis_password: Option<String>,
+
+    /// Whether to talk to the redis server using RESP3 rather than the default
+    /// protocol version.
     pub redis_use_resp3: bool,
 }
 
 #[derive(Clone)]
 pub struct DeadLetterQueueConfig {
-    // The name of the deadletter queue, which is a simple
-    // list data type.
+    /// The name of the deadletter queue, which is a simple
+    /// list data type.
     pub queue_key: String,
     /// The number of times a message may be received before
     /// being sent to the deadletter queue.

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -1,3 +1,59 @@
+//! Amazon SQS queue implementation.
+//!
+//! # The Implementation
+//!
+//! A queue is identified by its URL, which is what [`SqsConfig::queue_dsn`]
+//! holds. It has to exist already. Unlike the other backends, the payload type
+//! is `String` rather than bytes, because an SQS message body is text.
+//!
+//! Acking a delivery deletes the message. Nacking one does nothing at all, so
+//! the message stays invisible until its visibility timeout runs out and SQS
+//! hands it out again. To get a nacked message back sooner, shorten that
+//! timeout with `Delivery::set_ack_deadline`, which needs the `beta` feature.
+//!
+//! # Credentials
+//!
+//! By default the AWS configuration is read from the process environment, via
+//! [`aws_config::load_from_env`]. Two builder methods change that:
+//!
+//! - `sqs_config` supplies an [`aws_sdk_sqs::Config`] directly, and takes
+//!   precedence over everything else.
+//! - `override_endpoint` points the client at the queue DSN instead of the real
+//!   AWS endpoint, which is how you talk to a local stand-in such as ElasticMQ.
+//!
+//! # Limits
+//!
+//! Sends over `max_payload_size` fail with [`QueueError::PayloadTooLarge`]
+//! before anything reaches SQS. The default is the largest size SQS accepts.
+//!
+//! SQS hands out at most 10 messages per receive, which is what `max_messages`
+//! reports, and batch sends are split into chunks of 10 for the same reason.
+//!
+//! A scheduled send passes the delay as whole seconds, so anything under a
+//! second is rounded down to no delay. SQS caps the delay at 15 minutes.
+//!
+//! # Unsupported Operations
+//!
+//! `QueueProducer::redrive_dlq` returns [`QueueError::Unsupported`]. SQS has
+//! dead-letter queues, but they are configured on the queue with a redrive
+//! policy, not through omniqueue.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # async {
+//! use omniqueue::backends::{SqsBackend, SqsConfig};
+//!
+//! let cfg = SqsConfig {
+//!     queue_dsn: "https://sqs.us-east-1.amazonaws.com/123456789012/my-queue".to_owned(),
+//!     override_endpoint: false,
+//! };
+//!
+//! let (p, mut c) = SqsBackend::builder(cfg).build_pair().await?;
+//! # anyhow::Ok(())
+//! # };
+//! ```
+
 use std::{
     fmt::{self, Write},
     future::Future,
@@ -27,10 +83,18 @@ const MAX_BATCH_SIZE: usize = 10;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SqsConfig {
-    /// The queue's [DSN](https://aws.amazon.com/route53/what-is-dns/).
+    /// The [URL of the queue][queue-url], which is what identifies it to SQS.
+    ///
+    /// For example
+    /// `https://sqs.us-east-1.amazonaws.com/123456789012/my-queue`.
+    ///
+    /// [queue-url]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-message-identifiers.html
     pub queue_dsn: String,
 
     /// Whether to override the AWS endpoint URL with the queue DSN.
+    ///
+    /// Turn this on to point the client at something other than real AWS, such
+    /// as ElasticMQ or another local stand-in.
     pub override_endpoint: bool,
 }
 

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -9,14 +9,26 @@
 //!
 //! ## Cargo Features
 //!
-//! Each backend is enabled with its associated cargo feature. All backends are
-//! enabled by default. As of present it supports:
+//! Each backend is enabled with its associated cargo feature. These are on by
+//! default:
 //!
-//! * In-memory queue
-//! * Google Cloud Pub/Sub
-//! * RabbitMQ
-//! * Redis
-//! * Amazon SQS
+//! * `in_memory`, an in-memory queue
+//! * `gcp_pubsub`, Google Cloud Pub/Sub
+//! * `rabbitmq`, RabbitMQ
+//! * `redis`, Redis
+//! * `redis_cluster`, clustered Redis
+//! * `sqs`, Amazon SQS
+//!
+//! These are off by default:
+//!
+//! * `redis_sentinel`, Redis behind sentinel
+//! * `rabbitmq-with-message-ids`, has the RabbitMQ producer set a message ID on
+//!   every message. Likely not needed outside of Svix.
+//! * `beta`, enables `Delivery::set_ack_deadline`, which not every backend
+//!   supports. Not stable yet.
+//!
+//! Each backend's own module under [`backends`] covers its configuration and
+//! which operations it supports.
 //!
 //! ## How to Use Omniqueue
 //!

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -103,11 +103,18 @@ impl Delivery {
         self.payload.take()
     }
 
-    /// This method
+    /// Borrows the contained bytes, doing no further processing.
+    ///
+    /// Returns `None` if the payload was already taken out with
+    /// [`take_payload`][Self::take_payload].
     pub fn borrow_payload(&self) -> Option<&[u8]> {
         self.payload.as_deref()
     }
 
+    /// Deserializes the contained bytes from JSON.
+    ///
+    /// Returns `Ok(None)` if the payload was already taken out with
+    /// [`take_payload`][Self::take_payload].
     pub fn payload_serde_json<T: DeserializeOwned>(&self) -> Result<Option<T>> {
         let Some(bytes) = self.payload.as_ref() else {
             return Ok(None);


### PR DESCRIPTION
Part of #9, covering the first checklist group. High-level concepts will follow in a second PR.

Adds module docs to every backend and doc comments to every public config field. **No logic changes.**
**Things that weren't documented anywhere:**
- **RabbitMQ** delayed sending only works with the [delayed message exchange plugin](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange). Without it the broker ignores the `x-delay` header and delivers immediately rather than failing.
- Several **`RedisConfig`** fields only apply to one implementation: `consumer_group`, `consumer_name` and `payload_key` are streams only, the processing queue key is fallback only.
- A **Redis nack** doesn't reinsert the message. Redelivery waits out `ack_deadline_ms`.
- An empty **`delayed_queue_key`** means the delayed scheduler never starts, so a delayed send is accepted but never delivered.
- **Redis** needs `maxmemory-policy` set to `noeviction` or `volatile-*`, or queue keys can be evicted and messages lost.
- **GCP Pub/Sub** is the only backend that can't send with a delay.

**Small doc bugs fixed along the way:**

- `Delivery::borrow_payload`'s doc comment was the truncated sentence "This method".
- `DeadLetterQueueConfig::queue_key` used `//` instead of `///`, so it never rendered.
- `SqsConfig::queue_dsn` described the DSN with a link to a page about DNS.
- Crate docs said all backends are on by default, but `redis_sentinel` isn't, and `beta` and `rabbitmq-with-message-ids` weren't mentioned.

**One question:** I documented `RedisConfig::reinsert_on_nack` as currently unused, since nothing in `src/` reads it. Both implementations leave a nacked message in place for the background task to redeliver. Deprecate the field, or wire it up to do what the name suggests? if u prefer another approach i will reshape Pr accordingly.
