### PR TITLE
Make it possible to detect partially-successful batch send operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Breaking changes
 
 - Remove support for Azure queues due to the deprecation of the `azure_storage_queues` crate
+- Change signature of `Error::generic` to allow more parameter types (use
+  `impl Into<Box<dyn std::error::Error + Send + Sync>>` instead of
+  `impl std::error::Error + Send + Sync + 'static`)
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Change signature of `Error::generic` to allow more parameter types (use
   `impl Into<Box<dyn std::error::Error + Send + Sync>>` instead of
   `impl std::error::Error + Send + Sync + 'static`)
+- The batch-sending methods now return `Result<BatchResult>` instead of `Result<()>`,
+  to be able to represent partially-successful batch send operations
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Delete the `QueueBuilder` type and `QueueBackend` trait
   - The in-memory backend is now constructed using `InMemoryBackend::new_pair()`
   - Every other backend now has its own builder type now
+- Change signature of `Error::generic` to allow more parameter types (use
+  `impl Into<Box<dyn std::error::Error + Send + Sync>>` instead of
+  `impl std::error::Error + Send + Sync + 'static`)
 
 # 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Change signature of `Error::generic` to allow more parameter types (use
   `impl Into<Box<dyn std::error::Error + Send + Sync>>` instead of
   `impl std::error::Error + Send + Sync + 'static`)
+- The batch-sending methods now return `Result<BatchResult>` instead of `Result<()>`,
+  to be able to represent partially-successful batch send operations
 
 # 0.3.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,6 +2206,7 @@ dependencies = [
  "sync_wrapper",
  "thiserror",
  "tokio",
+ "tonic",
  "tracing",
 ]
 

--- a/omniqueue/Cargo.toml
+++ b/omniqueue/Cargo.toml
@@ -25,6 +25,7 @@ svix-ksuid = { version = "0.10.0", default-features = false, optional = true }
 sync_wrapper = "1.0.1"
 thiserror = "2.0"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
+tonic = { version = "0.14.5", default-features = false, optional = true }
 tracing = "0.1"
 
 [dev-dependencies]
@@ -39,7 +40,7 @@ tokio = { version = "1", features = ["macros"] }
 [features]
 default = ["in_memory", "gcp_pubsub", "rabbitmq", "redis", "redis_cluster", "sqs"]
 in_memory = []
-gcp_pubsub = ["dep:futures-util", "dep:gcloud-googleapis", "dep:gcloud-pubsub"]
+gcp_pubsub = ["dep:futures-util", "dep:gcloud-googleapis", "dep:gcloud-pubsub", "dep:tonic"]
 rabbitmq = ["dep:futures-util", "dep:lapin"]
 # Generate message IDs for queue items. Likely not needed outside of Svix.
 rabbitmq-with-message-ids = ["rabbitmq", "dep:svix-ksuid"]

--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use futures_util::{future::try_join_all, StreamExt};
+use futures_util::{future::join_all, StreamExt};
 use gcloud_googleapis::pubsub::v1::PubsubMessage;
 use gcloud_pubsub::{
     client::{google_cloud_auth::credentials::CredentialsFile, Client, ClientConfig},
@@ -18,7 +18,7 @@ use serde::Serialize;
 use crate::{
     builder::{QueueBuilder, Static},
     queue::{Acker, Delivery, QueueBackend},
-    QueueError, Result,
+    BatchResult, QueueError, Result,
 };
 
 pub struct GcpPubSubBackend;
@@ -172,6 +172,28 @@ impl GcpPubSubProducer {
             "redrive_dlq is not supported by GcpPubSubBackend",
         ))
     }
+
+    async fn send_batch_inner(
+        &self,
+        msgs: Vec<PubsubMessage>,
+    ) -> std::prelude::v1::Result<BatchResult, QueueError> {
+        let publisher = self.publisher().await?;
+        let awaiters = publisher.publish_bulk(msgs).await;
+        let results = join_all(awaiters.into_iter().map(|a| a.get())).await;
+
+        let failures = results
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, res)| match res {
+                Ok(_) => None,
+                // probably unreachable?
+                Err(s) if s.code() == tonic::Code::Ok => None,
+                Err(s) => Some((idx, QueueError::generic(s))),
+            })
+            .collect();
+
+        Ok(BatchResult { failures })
+    }
 }
 
 impl std::fmt::Debug for GcpPubSubProducer {
@@ -192,7 +214,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
     async fn send_raw_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-    ) -> Result<()> {
+    ) -> Result<BatchResult> {
         let msgs = payloads
             .into_iter()
             .map(|payload| PubsubMessage {
@@ -201,12 +223,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
             })
             .collect();
 
-        let publisher = self.publisher().await?;
-        let awaiters = publisher.publish_bulk(msgs).await;
-        try_join_all(awaiters.into_iter().map(|a| a.get()))
-            .await
-            .map_err(QueueError::generic)?;
-        Ok(())
+        self.send_batch_inner(msgs).await
     }
 
     /// This method is overwritten for the Google Cloud Pub/Sub backend to be
@@ -215,7 +232,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
     async fn send_serde_json_batch(
         &self,
         payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-    ) -> Result<()> {
+    ) -> Result<BatchResult> {
         let msgs = payloads
             .into_iter()
             .map(|payload| {
@@ -226,12 +243,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
             })
             .collect::<Result<_>>()?;
 
-        let publisher = self.publisher().await?;
-        let awaiters = publisher.publish_bulk(msgs).await;
-        try_join_all(awaiters.into_iter().map(|a| a.get()))
-            .await
-            .map_err(QueueError::generic)?;
-        Ok(())
+        self.send_batch_inner(msgs).await
     }
 }
 

--- a/omniqueue/src/backends/gcp_pubsub.rs
+++ b/omniqueue/src/backends/gcp_pubsub.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use futures_util::{future::try_join_all, StreamExt};
+use futures_util::{future::join_all, StreamExt};
 use gcloud_googleapis::pubsub::v1::PubsubMessage;
 use gcloud_pubsub::{
     client::{google_cloud_auth::credentials::CredentialsFile, Client, ClientConfig},
@@ -16,7 +16,7 @@ use serde::Serialize;
 
 use crate::{
     queue::{Acker, Delivery},
-    QueueError, Result,
+    BatchResult, QueueError, Result,
 };
 
 pub struct GcpPubSubBackend;
@@ -168,6 +168,28 @@ impl GcpPubSubProducer {
             "redrive_dlq is not supported by GcpPubSubBackend",
         ))
     }
+
+    async fn send_batch_inner(
+        &self,
+        msgs: Vec<PubsubMessage>,
+    ) -> std::prelude::v1::Result<BatchResult, QueueError> {
+        let publisher = self.publisher().await?;
+        let awaiters = publisher.publish_bulk(msgs).await;
+        let results = join_all(awaiters.into_iter().map(|a| a.get())).await;
+
+        let failures = results
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, res)| match res {
+                Ok(_) => None,
+                // probably unreachable?
+                Err(s) if s.code() == tonic::Code::Ok => None,
+                Err(s) => Some((idx, QueueError::generic(s))),
+            })
+            .collect();
+
+        Ok(BatchResult { failures })
+    }
 }
 
 impl std::fmt::Debug for GcpPubSubProducer {
@@ -188,7 +210,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
     async fn send_raw_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-    ) -> Result<()> {
+    ) -> Result<BatchResult> {
         let msgs = payloads
             .into_iter()
             .map(|payload| PubsubMessage {
@@ -197,12 +219,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
             })
             .collect();
 
-        let publisher = self.publisher().await?;
-        let awaiters = publisher.publish_bulk(msgs).await;
-        try_join_all(awaiters.into_iter().map(|a| a.get()))
-            .await
-            .map_err(QueueError::generic)?;
-        Ok(())
+        self.send_batch_inner(msgs).await
     }
 
     /// This method is overwritten for the Google Cloud Pub/Sub backend to be
@@ -211,7 +228,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
     async fn send_serde_json_batch(
         &self,
         payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-    ) -> Result<()> {
+    ) -> Result<BatchResult> {
         let msgs = payloads
             .into_iter()
             .map(|payload| {
@@ -222,12 +239,7 @@ impl crate::QueueProducer for GcpPubSubProducer {
             })
             .collect::<Result<_>>()?;
 
-        let publisher = self.publisher().await?;
-        let awaiters = publisher.publish_bulk(msgs).await;
-        try_join_all(awaiters.into_iter().map(|a| a.get()))
-            .await
-            .map_err(QueueError::generic)?;
-        Ok(())
+        self.send_batch_inner(msgs).await
     }
 }
 

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use aws_sdk_sqs::{
-    operation::delete_message::DeleteMessageError,
+    operation::{delete_message::DeleteMessageError, send_message_batch::SendMessageBatchOutput},
     types::{error::ReceiptHandleIsInvalid, Message, SendMessageBatchRequestEntry},
     Client,
 };
@@ -15,7 +15,7 @@ use serde::Serialize;
 
 use crate::{
     queue::{Acker, Delivery},
-    QueueError, Result,
+    BatchResult, QueueError, Result,
 };
 
 /// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
@@ -321,7 +321,7 @@ impl SqsProducer {
         &self,
         payloads: impl IntoIterator<Item = I, IntoIter: Send> + Send,
         convert_payload: impl Fn(I) -> Result<String>,
-    ) -> Result<()> {
+    ) -> Result<BatchResult> {
         // Convert payloads up front and collect to Vec to run the payload size
         // check on everything before submitting the first batch.
         let payloads: Vec<_> = payloads
@@ -338,7 +338,9 @@ impl SqsProducer {
             }
         }
 
-        for payloads in payloads.chunks(MAX_BATCH_SIZE) {
+        let mut chunk_idx = 0;
+        let mut payloads_iter = payloads.chunks(MAX_BATCH_SIZE);
+        while let Some(payloads) = payloads_iter.next() {
             let entries = payloads
                 .iter()
                 .enumerate()
@@ -351,7 +353,8 @@ impl SqsProducer {
                 })
                 .collect::<Result<_>>()?;
 
-            self.client
+            let batch_result = self
+                .client
                 .send_message_batch()
                 .queue_url(&self.queue_dsn)
                 .set_entries(Some(entries))
@@ -360,9 +363,15 @@ impl SqsProducer {
                 .boxed()
                 .await
                 .map_err(aws_to_queue_error)?;
+
+            if batch_result.failed.is_empty() {
+                chunk_idx += 1;
+            } else {
+                return Ok(finalize_batch(chunk_idx, payloads_iter, batch_result));
+            }
         }
 
-        Ok(())
+        Ok(BatchResult::OK)
     }
 
     pub async fn redrive_dlq(&self) -> Result<()> {
@@ -370,6 +379,44 @@ impl SqsProducer {
             "redrive_dlq is not supported by SqsBackend",
         ))
     }
+}
+
+fn finalize_batch(
+    chunk_idx: usize,
+    remaining_payloads: std::slice::Chunks<'_, String>,
+    batch_result: SendMessageBatchOutput,
+) -> BatchResult {
+    let mut failures = Vec::new();
+    let batch_start_idx = chunk_idx * MAX_BATCH_SIZE;
+
+    for error_entry in batch_result.failed {
+        let mut msg = String::new();
+        let idx = if let Ok(idx) = error_entry.id.parse::<usize>() {
+            batch_start_idx + idx
+        } else {
+            // kinda ugly, but should never happen in practice anyways
+            msg = format!("Unexpected failed message ID `{}` AND ", error_entry.id);
+            0
+        };
+
+        write!(msg, "[{}]", error_entry.code).unwrap();
+        if let Some(message) = error_entry.message {
+            write!(msg, " {message}").unwrap();
+        }
+
+        failures.push((idx, QueueError::generic(msg)));
+    }
+
+    // if the failed chunk wasn't the last, report all remaining messages as failed
+    // without attempting to send them.
+    for (idx, _) in remaining_payloads.flatten().enumerate() {
+        failures.push((
+            batch_start_idx + idx,
+            QueueError::generic("not attempted because an earlier message failed"),
+        ));
+    }
+
+    BatchResult { failures }
 }
 
 impl crate::QueueProducer for SqsProducer {
@@ -381,7 +428,7 @@ impl crate::QueueProducer for SqsProducer {
     fn send_raw_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> {
+    ) -> impl Future<Output = Result<BatchResult>> {
         self.send_batch_inner(payloads, |p| Ok(p.as_ref().into()))
     }
 
@@ -390,7 +437,7 @@ impl crate::QueueProducer for SqsProducer {
     fn send_serde_json_batch(
         &self,
         payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> {
+    ) -> impl Future<Output = Result<BatchResult>> {
         self.send_batch_inner(payloads, |p| Ok(serde_json::to_string(&p)?))
     }
 }

--- a/omniqueue/src/backends/sqs.rs
+++ b/omniqueue/src/backends/sqs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use aws_sdk_sqs::{
-    operation::delete_message::DeleteMessageError,
+    operation::{delete_message::DeleteMessageError, send_message_batch::SendMessageBatchOutput},
     types::{error::ReceiptHandleIsInvalid, Message, SendMessageBatchRequestEntry},
     Client,
 };
@@ -17,7 +17,7 @@ use serde::Serialize;
 use crate::{
     builder::{QueueBuilder, Static},
     queue::{Acker, Delivery, QueueBackend},
-    QueueError, Result,
+    BatchResult, QueueError, Result,
 };
 
 /// https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
@@ -346,7 +346,7 @@ impl SqsProducer {
         &self,
         payloads: impl IntoIterator<Item = I, IntoIter: Send> + Send,
         convert_payload: impl Fn(I) -> Result<String>,
-    ) -> Result<()> {
+    ) -> Result<BatchResult> {
         // Convert payloads up front and collect to Vec to run the payload size
         // check on everything before submitting the first batch.
         let payloads: Vec<_> = payloads
@@ -363,7 +363,9 @@ impl SqsProducer {
             }
         }
 
-        for payloads in payloads.chunks(MAX_BATCH_SIZE) {
+        let mut chunk_idx = 0;
+        let mut payloads_iter = payloads.chunks(MAX_BATCH_SIZE);
+        while let Some(payloads) = payloads_iter.next() {
             let entries = payloads
                 .iter()
                 .enumerate()
@@ -376,7 +378,8 @@ impl SqsProducer {
                 })
                 .collect::<Result<_>>()?;
 
-            self.client
+            let batch_result = self
+                .client
                 .send_message_batch()
                 .queue_url(&self.queue_dsn)
                 .set_entries(Some(entries))
@@ -385,9 +388,15 @@ impl SqsProducer {
                 .boxed()
                 .await
                 .map_err(aws_to_queue_error)?;
+
+            if batch_result.failed.is_empty() {
+                chunk_idx += 1;
+            } else {
+                return Ok(finalize_batch(chunk_idx, payloads_iter, batch_result));
+            }
         }
 
-        Ok(())
+        Ok(BatchResult::OK)
     }
 
     pub async fn redrive_dlq(&self) -> Result<()> {
@@ -395,6 +404,44 @@ impl SqsProducer {
             "redrive_dlq is not supported by SqsBackend",
         ))
     }
+}
+
+fn finalize_batch(
+    chunk_idx: usize,
+    remaining_payloads: std::slice::Chunks<'_, String>,
+    batch_result: SendMessageBatchOutput,
+) -> BatchResult {
+    let mut failures = Vec::new();
+    let batch_start_idx = chunk_idx * MAX_BATCH_SIZE;
+
+    for error_entry in batch_result.failed {
+        let mut msg = String::new();
+        let idx = if let Ok(idx) = error_entry.id.parse::<usize>() {
+            batch_start_idx + idx
+        } else {
+            // kinda ugly, but should never happen in practice anyways
+            msg = format!("Unexpected failed message ID `{}` AND ", error_entry.id);
+            0
+        };
+
+        write!(msg, "[{}]", error_entry.code).unwrap();
+        if let Some(message) = error_entry.message {
+            write!(msg, " {message}").unwrap();
+        }
+
+        failures.push((idx, QueueError::generic(msg)));
+    }
+
+    // if the failed chunk wasn't the last, report all remaining messages as failed
+    // without attempting to send them.
+    for (idx, _) in remaining_payloads.flatten().enumerate() {
+        failures.push((
+            batch_start_idx + idx,
+            QueueError::generic("not attempted because an earlier message failed"),
+        ));
+    }
+
+    BatchResult { failures }
 }
 
 impl crate::QueueProducer for SqsProducer {
@@ -406,7 +453,7 @@ impl crate::QueueProducer for SqsProducer {
     fn send_raw_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> {
+    ) -> impl Future<Output = Result<BatchResult>> {
         self.send_batch_inner(payloads, |p| Ok(p.as_ref().into()))
     }
 
@@ -415,7 +462,7 @@ impl crate::QueueProducer for SqsProducer {
     fn send_serde_json_batch(
         &self,
         payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> {
+    ) -> impl Future<Output = Result<BatchResult>> {
         self.send_batch_inner(payloads, |p| Ok(serde_json::to_string(&p)?))
     }
 }

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -101,8 +101,8 @@ mod scheduled;
 #[allow(deprecated)]
 pub use self::{
     queue::{
-        Acker, BaseDynConsumer, BaseDynProducer, Delivery, DynConsumer, DynProducer, QueueConsumer,
-        QueueProducer,
+        Acker, BaseDynConsumer, BaseDynProducer, BatchResult, Delivery, DynConsumer, DynProducer,
+        QueueConsumer, QueueProducer,
     },
     scheduled::{BaseDynScheduledProducer, DynScheduledProducer, ScheduledQueueProducer},
 };

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -142,8 +142,8 @@ pub enum QueueError {
 }
 
 impl QueueError {
-    pub fn generic<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
-        Self::Generic(Box::new(e))
+    pub fn generic(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self::Generic(e.into())
     }
 }
 

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -101,8 +101,8 @@ mod scheduled;
 pub use self::{
     builder::QueueBuilder,
     queue::{
-        Acker, BaseDynConsumer, BaseDynProducer, Delivery, DynConsumer, DynProducer, QueueBackend,
-        QueueConsumer, QueueProducer,
+        Acker, BaseDynConsumer, BaseDynProducer, BatchResult, Delivery, DynConsumer, DynProducer,
+        QueueBackend, QueueConsumer, QueueProducer,
     },
     scheduled::{BaseDynScheduledProducer, DynScheduledProducer, ScheduledQueueProducer},
 };

--- a/omniqueue/src/lib.rs
+++ b/omniqueue/src/lib.rs
@@ -139,8 +139,8 @@ pub enum QueueError {
 }
 
 impl QueueError {
-    pub fn generic<E: std::error::Error + Send + Sync + 'static>(e: E) -> Self {
-        Self::Generic(Box::new(e))
+    pub fn generic(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self::Generic(e.into())
     }
 }
 

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use self::producer::ErasedQueueProducer;
 pub use self::{
     acker::Acker,
     consumer::{BaseDynConsumer, DynConsumer, QueueConsumer},
-    producer::{BaseDynProducer, DynProducer, QueueProducer},
+    producer::{BaseDynProducer, BatchResult, DynProducer, QueueProducer},
 };
 
 /// A marker trait with utility functions meant for the creation of new

--- a/omniqueue/src/queue/mod.rs
+++ b/omniqueue/src/queue/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use self::producer::ErasedQueueProducer;
 pub use self::{
     acker::Acker,
     consumer::{BaseDynConsumer, DynConsumer, QueueConsumer},
-    producer::{BaseDynProducer, DynProducer, QueueProducer},
+    producer::{BaseDynProducer, BatchResult, DynProducer, QueueProducer},
 };
 
 /// The output of queue backends

--- a/omniqueue/src/queue/producer.rs
+++ b/omniqueue/src/queue/producer.rs
@@ -2,7 +2,7 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 use serde::Serialize;
 
-use crate::{QueuePayload, Result};
+use crate::{QueueError, QueuePayload, Result};
 
 pub trait QueueProducer: Send + Sync + Sized {
     type Payload: QueuePayload;
@@ -20,12 +20,12 @@ pub trait QueueProducer: Send + Sync + Sized {
     fn send_raw_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> + Send {
+    ) -> impl Future<Output = Result<BatchResult>> + Send {
         async move {
             for payload in payloads {
                 self.send_raw(payload.as_ref()).await?;
             }
-            Ok(())
+            Ok(BatchResult::OK)
         }
     }
 
@@ -40,7 +40,7 @@ pub trait QueueProducer: Send + Sync + Sized {
     fn send_bytes_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<[u8]> + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> + Send {
+    ) -> impl Future<Output = Result<BatchResult>> + Send {
         async move {
             let payloads: Vec<_> = payloads
                 .into_iter()
@@ -64,7 +64,7 @@ pub trait QueueProducer: Send + Sync + Sized {
     fn send_serde_json_batch(
         &self,
         payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> + Send {
+    ) -> impl Future<Output = Result<BatchResult>> + Send {
         async move {
             let payloads: Vec<_> = payloads
                 .into_iter()
@@ -85,6 +85,25 @@ pub trait QueueProducer: Send + Sync + Sized {
     }
 }
 
+/// Result of a batch-send operation.
+///
+/// If a batch-send partially succeeds, the relevant method will return
+/// `Result::Ok(batch_result)`, with `batch_result` containing the positions
+/// (zero-indexed) and messages for the failures.
+#[must_use]
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct BatchResult {
+    /// List of `(position from batch-send call, error)`s.
+    pub failures: Vec<(usize, QueueError)>,
+}
+
+impl BatchResult {
+    pub(crate) const OK: Self = Self {
+        failures: Vec::new(),
+    };
+}
+
 macro_rules! ref_delegate {
     ($ty_param:ident, $ty:ty) => {
         #[deny(unconditional_recursion)]
@@ -101,7 +120,7 @@ macro_rules! ref_delegate {
             fn send_raw_batch(
                 &self,
                 payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-            ) -> impl Future<Output = Result<()>> + Send {
+            ) -> impl Future<Output = Result<BatchResult>> + Send {
                 (**self).send_raw_batch(payloads)
             }
 
@@ -112,7 +131,7 @@ macro_rules! ref_delegate {
             fn send_bytes_batch(
                 &self,
                 payloads: impl IntoIterator<Item: AsRef<[u8]> + Send, IntoIter: Send> + Send,
-            ) -> impl Future<Output = Result<()>> + Send {
+            ) -> impl Future<Output = Result<BatchResult>> + Send {
                 (**self).send_bytes_batch(payloads)
             }
 
@@ -126,7 +145,7 @@ macro_rules! ref_delegate {
             fn send_serde_json_batch(
                 &self,
                 payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-            ) -> impl Future<Output = Result<()>> + Send {
+            ) -> impl Future<Output = Result<BatchResult>> + Send {
                 (**self).send_serde_json_batch(payloads)
             }
 

--- a/omniqueue/src/queue/producer.rs
+++ b/omniqueue/src/queue/producer.rs
@@ -2,7 +2,7 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 use serde::Serialize;
 
-use crate::{QueuePayload, Result};
+use crate::{QueueError, QueuePayload, Result};
 
 pub trait QueueProducer: Send + Sync + Sized {
     type Payload: QueuePayload;
@@ -20,12 +20,12 @@ pub trait QueueProducer: Send + Sync + Sized {
     fn send_raw_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> + Send {
+    ) -> impl Future<Output = Result<BatchResult>> + Send {
         async move {
             for payload in payloads {
                 self.send_raw(payload.as_ref()).await?;
             }
-            Ok(())
+            Ok(BatchResult::OK)
         }
     }
 
@@ -40,7 +40,7 @@ pub trait QueueProducer: Send + Sync + Sized {
     fn send_bytes_batch(
         &self,
         payloads: impl IntoIterator<Item: AsRef<[u8]> + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> + Send {
+    ) -> impl Future<Output = Result<BatchResult>> + Send {
         async move {
             let payloads: Vec<_> = payloads
                 .into_iter()
@@ -64,7 +64,7 @@ pub trait QueueProducer: Send + Sync + Sized {
     fn send_serde_json_batch(
         &self,
         payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-    ) -> impl Future<Output = Result<()>> + Send {
+    ) -> impl Future<Output = Result<BatchResult>> + Send {
         async move {
             let payloads: Vec<_> = payloads
                 .into_iter()
@@ -85,6 +85,26 @@ pub trait QueueProducer: Send + Sync + Sized {
     }
 }
 
+/// Result of a batch-send operation.
+///
+/// If a batch-send partially succeeds, the relevant method will return
+/// `Result::Ok(batch_result)`, with `batch_result` containing the positions
+/// (zero-indexed) and messages for the failures.
+#[must_use]
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct BatchResult {
+    /// List of `(position from batch-send call, error)`s.
+    pub failures: Vec<(usize, QueueError)>,
+}
+
+impl BatchResult {
+    /// A `BatchResult` with no failures.
+    pub const OK: Self = Self {
+        failures: Vec::new(),
+    };
+}
+
 macro_rules! ref_delegate {
     ($ty_param:ident, $ty:ty) => {
         #[deny(unconditional_recursion)]
@@ -101,7 +121,7 @@ macro_rules! ref_delegate {
             fn send_raw_batch(
                 &self,
                 payloads: impl IntoIterator<Item: AsRef<Self::Payload> + Send, IntoIter: Send> + Send,
-            ) -> impl Future<Output = Result<()>> + Send {
+            ) -> impl Future<Output = Result<BatchResult>> + Send {
                 (**self).send_raw_batch(payloads)
             }
 
@@ -112,7 +132,7 @@ macro_rules! ref_delegate {
             fn send_bytes_batch(
                 &self,
                 payloads: impl IntoIterator<Item: AsRef<[u8]> + Send, IntoIter: Send> + Send,
-            ) -> impl Future<Output = Result<()>> + Send {
+            ) -> impl Future<Output = Result<BatchResult>> + Send {
                 (**self).send_bytes_batch(payloads)
             }
 
@@ -126,7 +146,7 @@ macro_rules! ref_delegate {
             fn send_serde_json_batch(
                 &self,
                 payloads: impl IntoIterator<Item: Serialize + Send, IntoIter: Send> + Send,
-            ) -> impl Future<Output = Result<()>> + Send {
+            ) -> impl Future<Output = Result<BatchResult>> + Send {
                 (**self).send_serde_json_batch(payloads)
             }
 

--- a/omniqueue/tests/it/gcp_pubsub.rs
+++ b/omniqueue/tests/it/gcp_pubsub.rs
@@ -348,7 +348,8 @@ async fn test_send_raw_batch() {
     let payloads: Vec<Vec<u8>> = (0..COUNT)
         .map(|i| format!("payload-{i}").into_bytes())
         .collect();
-    p.send_raw_batch(payloads.clone()).await.unwrap();
+    let batch_res = p.send_raw_batch(payloads.clone()).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&mut c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);
@@ -370,7 +371,8 @@ async fn test_send_serde_json_batch() {
     let (p, mut c) = make_test_queue().await.build_pair().await.unwrap();
 
     let payloads: Vec<ExType> = (0..COUNT).map(|i| ExType { a: i as u8 }).collect();
-    p.send_serde_json_batch(payloads).await.unwrap();
+    let batch_res = p.send_serde_json_batch(payloads).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&mut c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);
@@ -393,7 +395,8 @@ async fn test_send_bytes_batch() {
     let payloads: Vec<Vec<u8>> = (0..COUNT)
         .map(|i| format!("payload-{i}").into_bytes())
         .collect();
-    p.send_bytes_batch(payloads.clone()).await.unwrap();
+    let batch_res = p.send_bytes_batch(payloads.clone()).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&mut c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);

--- a/omniqueue/tests/it/sqs.rs
+++ b/omniqueue/tests/it/sqs.rs
@@ -362,7 +362,8 @@ async fn test_send_raw_batch_chunks_larger_batches() {
     let payloads: Vec<Box<String>> = (0..COUNT)
         .map(|i| Box::new(format!("payload-{i}")))
         .collect();
-    p.send_raw_batch(payloads.clone()).await.unwrap();
+    let batch_res = p.send_raw_batch(payloads.clone()).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);
@@ -390,7 +391,8 @@ async fn test_send_serde_json_batch_chunks_larger_batches() {
     let (p, c) = make_test_queue(None).await.build_pair().await;
 
     let payloads: Vec<ExType> = (0..COUNT).map(|i| ExType { a: i as u8 }).collect();
-    p.send_serde_json_batch(payloads).await.unwrap();
+    let batch_res = p.send_serde_json_batch(payloads).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);
@@ -479,7 +481,8 @@ async fn test_send_bytes_batch_chunks_larger_batches() {
     let payloads: Vec<Vec<u8>> = (0..COUNT)
         .map(|i| format!("payload-{i}").into_bytes())
         .collect();
-    p.send_bytes_batch(payloads.clone()).await.unwrap();
+    let batch_res = p.send_bytes_batch(payloads.clone()).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);

--- a/omniqueue/tests/it/sqs.rs
+++ b/omniqueue/tests/it/sqs.rs
@@ -365,7 +365,8 @@ async fn test_send_raw_batch_chunks_larger_batches() {
     let payloads: Vec<Box<String>> = (0..COUNT)
         .map(|i| Box::new(format!("payload-{i}")))
         .collect();
-    p.send_raw_batch(payloads.clone()).await.unwrap();
+    let batch_res = p.send_raw_batch(payloads.clone()).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);
@@ -393,7 +394,8 @@ async fn test_send_serde_json_batch_chunks_larger_batches() {
     let (p, c) = make_test_queue(None).await.build_pair().await.unwrap();
 
     let payloads: Vec<ExType> = (0..COUNT).map(|i| ExType { a: i as u8 }).collect();
-    p.send_serde_json_batch(payloads).await.unwrap();
+    let batch_res = p.send_serde_json_batch(payloads).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);
@@ -484,7 +486,8 @@ async fn test_send_bytes_batch_chunks_larger_batches() {
     let payloads: Vec<Vec<u8>> = (0..COUNT)
         .map(|i| format!("payload-{i}").into_bytes())
         .collect();
-    p.send_bytes_batch(payloads.clone()).await.unwrap();
+    let batch_res = p.send_bytes_batch(payloads.clone()).await.unwrap();
+    assert_eq!(batch_res.failures.len(), 0);
 
     let deliveries = receive_n(&c, COUNT).await;
     assert_eq!(deliveries.len(), COUNT);


### PR DESCRIPTION
And use `#[must_use]` to the batch-result type (unlike the crates we're using internally :unamused:) so one can't miss to check for failures.

Closes #186.