### PR TITLE
Optimize into_dyn* for consuming, scheduled producing

### DIFF
--- a/omniqueue/src/queue/producer.rs
+++ b/omniqueue/src/queue/producer.rs
@@ -193,4 +193,11 @@ impl<'a> BaseDynProducer<'a> {
 impl<'a> crate::QueueProducer for BaseDynProducer<'a> {
     type Payload = Vec<u8>;
     omni_delegate!(send_raw, send_serde_json, redrive_dlq);
+
+    fn into_dyn<'b>(self) -> BaseDynProducer<'b>
+    where
+        Self: 'b,
+    {
+        self
+    }
 }

--- a/omniqueue/src/scheduled/mod.rs
+++ b/omniqueue/src/scheduled/mod.rs
@@ -155,4 +155,11 @@ impl<'a> crate::QueueProducer for BaseDynScheduledProducer<'a> {
 }
 impl<'a> crate::ScheduledQueueProducer for BaseDynScheduledProducer<'a> {
     omni_delegate!(send_raw_scheduled, send_serde_json_scheduled);
+
+    fn into_dyn_scheduled<'b>(self) -> BaseDynScheduledProducer<'b>
+    where
+        Self: 'b,
+    {
+        self
+    }
 }


### PR DESCRIPTION
Avoids a double indirection for nested calls of into_dyn / into_dyn_scheduled. We were already doing this for regular the producing code path, unclear why we didn't here.